### PR TITLE
New feature: added new switch --run to mbedhtrun to only run single binaries

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -144,12 +144,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         # Read serial and wait for binary execution end
         try:
             self.test_supervisor = get_host_test("run_binary_auto")
-            result = self.test_supervisor.test(self)
-
-            if result is not None:
-                self.print_result(result)
-            else:
-                self.notify("HOST: Passive mode...")
+            result = self.test_supervisor.test(self)    # This is blocking, waits for {end}
         except Exception, e:
             print str(e)
             self.print_result(self.RESULT_ERROR)

--- a/mbed_host_tests/host_tests/run_only_auto.py
+++ b/mbed_host_tests/host_tests/run_only_auto.py
@@ -31,7 +31,7 @@ class RunBinaryOnlyAuto():
                 stdout.write(c)
                 stdout.flush()
                 if '{end}' in c:
-                    return selftest.RESULT_SUCCESS
+                    return None
         except KeyboardInterrupt, _:
             selftest.notify("\r\n[CTRL+C] exit")
             result = selftest.RESULT_ERROR


### PR DESCRIPTION
# Description

Added new host test used to run binary on target and wait for `'{end}'` to indicate binary execution finished.
## Command line

New command line added, `--run` will flash binary declared in `-f` switch and wait for `{end}` on console. 
## Example test execution
- When you execute tests (no `--run` switch) host-tests package will call proper host test just after test properties will be captured.
- When you use option `--run` `mbedhtrun` will not engage in handshake with target and will not parse output. 
  - Special host test called `run_binary_auto` will be executed.
  - `run_binary_auto` in infinite loop forwards serial port output from target to your console.
  - `run_binary_auto` terminates after Ctrl+C signal or after `{echo}` will be printed to console.
### Example, test binary executed with --run switch

```
$ mbedhtrun -d I: -f ".\build\frdm-k64f-gcc\test\mbed-test-cpp.bin" -p COM61 -C 4 -c default --run
```

```
MBED: Instrumentation: "COM61" and disk: "I:"
HOST: Copy image onto target...
HOST: Initialize serial port...
...port ready!
HOST: Reset target...
tatic::init
{{timeout;10}}
{{host_test_name;default_auto}}
{{description;C++}}
{{test_id;MBED_12}}
{{start}}
Static::stack_test
Stack::init
Stack::hello
Stack::destroy
Static::check_init: OK
Heap::init
Heap::hello
Heap::check_init: OK
Heap::destroy
{{success}}
{{end}}
```

Note: No handshake with target, only raw console output from target. Script exited when `{end}` was detected on console. 
### Example, test executed 'normally' without --run option

```
$ mbedhtrun -d I: -f ".\build\frdm-k64f-gcc\test\mbed-test-cpp.bin" -p COM61 -C 4 -c default
```

```
MBED: Instrumentation: "COM61" and disk: "I:"
HOST: Copy image onto target...
HOST: Initialize serial port...
...port ready!
HOST: Reset target...
HOST: Unknown property: tatic::init
HOST: Property 'timeout' = '10'
HOST: Property 'host_test_name' = 'default_auto'
HOST: Property 'description' = 'C++'
HOST: Property 'test_id' = 'MBED_12'
HOST: Start test...
Static::stack_test
Stack::init
Stack::hello
Stack::destroy
Static::check_init: OK
Heap::init
Heap::hello
Heap::check_init: OK
Heap::destroy
{{success}}
{{end}}
```

Ctrl+C used to stop this script from execution.
Note: handshake was performed to get information about test case parameters like timeout or expected host test handling:

```
HOST: Property 'timeout' = '10'
HOST: Property 'host_test_name' = 'default_auto'
HOST: Property 'description' = 'C++'
HOST: Property 'test_id' = 'MBED_12'
```
