### PR TITLE
'sync' needs to be called to flush data

### DIFF
--- a/mbed_host_tests/host_tests_plugins/module_copy_shell.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_shell.py
@@ -56,7 +56,11 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
             if capabilitity == 'cp' or capabilitity == 'copy' or capabilitity == 'copy':
                 copy_method = capabilitity
                 cmd = [copy_method, image_path, destination_path]
-                result = self.run_command(cmd)
+                if os.name == 'posix':
+                    result = self.run_command(cmd, shell=False)
+                    result = self.run_command(["sync"])
+                else:
+                    result = self.run_command(cmd)
         return result
 
 


### PR DESCRIPTION
peripheral disks on linux systems. This patch
calls 'sync' after copying file to mbed on
linux.

The command 'cp' tends to fail when called with
shell=True. Hence here explictly pass shell=False
to 'call' function.
