### PR TITLE
Extra Python APIs to support Python derived test tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,20 +226,41 @@ $ python setup.py install
 $ sudo python setup.py install
 ```
 To test if your installation succeeded you can use the Python interpreter and import ```mbed_host_tests```:
-
 ```
 $ python
-Python 2.7.8 (default, Jun 30 2014, 16:03:49) [MSC v.1500 32 bit (Intel)] on win32
-Type "help", "copyright", "credits" or "license" for more information.
 >>> import mbed_host_tests
 >>> dir(mbed_host_tests)
-['DefaultAuto', 'DefaultTestSelector', 'DefaultTestSelectorBase', 'DetectPlatformTest', 'DevNullTest', 
-'EchoTest', 'HOSTREGISTRY', 'HelloTest', 'HostRegistry', 'OptionParser', 'RTCTest', 'StdioTest', 
-'TCPEchoClientTest', 'TCPEchoServerTest', 'UDPEchoClientTest', 'UDPEchoServerTest', 'WaitusTest', 
-'__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', 'get_host_test', 
-'host_tests', 'host_tests_plugins', 'host_tests_registry', 'host_tests_runner', 'init_host_test_cli_params', 
-'is_host_test']
+['DefaultAuto', 'DefaultTestSelector', 'DefaultTestSelectorBase', 'DetectPlatformTest',
+'DevNullTest', 'EchoTest', 'HOSTREGISTRY', 'HelloTest', 'HostRegistry', 'LWM2MClientAutoTest',
+'OptionParser', 'RTCTest', 'RunBinaryOnlyAuto', 'StdioTest', 'TCPEchoClientTest',
+'TCPEchoServerTest', 'TCPSocketServerEchoExtTest', 'UDPEchoClientTest', 'UDPEchoServerTest',
+'UDPSocketServerEchoExtTest', 'WaitusTest', '__builtins__', '__doc__', '__file__', '__name__',
+'__package__', '__path__', 'flash_dev', 'get_host_test', 'get_host_test_list', 'get_plugin_caps',
+'host_tests', 'host_tests_plugins', 'host_tests_registry', 'host_tests_runner',
+'init_host_test_cli_params', 'is_host_test', 'json', 'reset_dev', 'sleep', 'sys']
 ```
+To start working with ```mbedhtrun``` Python APIs you can experiment with ```flash_dev()``` and ```reset_dev()``` functions.
+We can list available mbed devices with ```mbedls``` command:
+```
+$ mbedls
++--------------+---------------------+------------+------------+---------------------------+
+|platform_name |platform_name_unique |mount_point |serial_port |target_id                  |
++--------------+---------------------+------------+------------+---------------------------+
+|K64F          |K64F[0]              |F:          |COM4        |0240022648cb1e7700b512e3cf |
++--------------+---------------------+------------+------------+---------------------------+
+```
+And use Python APIs to flash and reset this device accordingly.
+```
+$ python
+import mbed_host_tests as htrun
+>>> htrun.flash_dev(disk='F:',
+                    image_path=r'c:\Work\mbed-drivers\build\frdm-k64f-gcc\test\mbed-drivers-test-basic.bin')
+        1 file(s) copied.
+True
+>>> htrun.reset_dev(port='COM4')
+True
+```
+Note: ```c:\Work\mbed-drivers\build\frdm-k64f-gcc\test\mbed-drivers-test-basic.bin``` is valid path to ```K64F``` device's compatible binary.
 
 You can also check whether ```mbedhtrun``` is correctly installed in your system:
 ```

--- a/README.md
+++ b/README.md
@@ -262,6 +262,32 @@ True
 ```
 Note: ```c:\Work\mbed-drivers\build\frdm-k64f-gcc\test\mbed-drivers-test-basic.bin``` is valid path to ```K64F``` device's compatible binary.
 
+Example Python API fetch for available plugin capabilities. Note that ```json``` module was used here to pretty print of ```get_plugin_caps``` function.
+```
+$ python
+>>> import mbed_host_tests as htrun
+>>> import json
+>>> print json.dumps(htrun.get_plugin_caps(), indent=4)
+{
+    "ResetMethod": [
+        "default",
+        "eACommander",
+        "eACommander-usb",
+        "stlink"
+    ],
+    "CopyMethod": [
+        "copy",
+        "cp",
+        "default",
+        "eACommander",
+        "eACommander-usb",
+        "shell",
+        "shutil",
+        "stlink",
+        "xcopy"
+    ]
+}
+```
 You can also check whether ```mbedhtrun``` is correctly installed in your system:
 ```
 mbedhtrun --help

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -27,6 +27,7 @@ Write your own programs (import this package) or use 'mbedhtrun' command line to
 
 import sys
 import json
+from time import sleep
 from optparse import OptionParser
 
 import host_tests_plugins
@@ -80,9 +81,7 @@ HOSTREGISTRY.register_host_test("test_socket_server_tcp", TCPSocketServerEchoExt
 
 def get_host_test(ht_name):
     """! Fetches host test object from HOSTREGISTRY
-
     @param ht_name Host test name
-
     @return Returns registered host test supervisor.
             If host test is not registered by name function returns None.
     """
@@ -90,12 +89,85 @@ def get_host_test(ht_name):
 
 def is_host_test(ht_name):
     """! Checks if host test supervisor is registered in host test registry.
-
     @param ht_name Host test name
-
     @return If host test supervisor is registered returns True otherwise False.
     """
     return HOSTREGISTRY.is_host_test(ht_name)
+
+def get_host_test_list():
+    """! Returns list of host test names and its classes
+    @return Dictionary of {host_test_name : __class__}
+    """
+    result = {}
+    for ht in sorted(HOSTREGISTRY.HOST_TESTS.keys()):
+        result[ht] = HOSTREGISTRY.HOST_TESTS[ht].__class__
+    return result
+
+def get_plugin_caps(methods=None):
+    if not methods:
+        methods = ['CopyMethod', 'ResetMethod']
+    result = {}
+    for method in methods:
+        result[method] = host_tests_plugins.get_plugin_caps(method)
+    return result
+
+def flash_dev(disk=None,
+              image_path=None,
+              copy_method='default',
+              port=None,
+              program_cycle_s=0):
+    """! Flash device using pythonic interface
+    @param disk Switch -d <disk>
+    @param image_path Switch -f <image_path>
+    @param copy_method Switch -c <copy_method> (default: shell)
+    @param port Switch -p <port>
+    """
+    if copy_method == 'default':
+        copy_method = 'shell'
+    result = False
+    result = host_tests_plugins.call_plugin('CopyMethod',
+                                            copy_method,
+                                            image_path=image_path,
+                                            destination_disk=disk)
+    sleep(program_cycle_s)
+    return result
+
+def reset_dev(port=None,
+              disk=None,
+              reset_type=None,
+              reset_timeout=1,
+              serial_port=None,
+              baudrate=9600,
+              timeout=1,
+              verbose=False):
+    """! Reset device using pythonic interface
+    @param port Switch -p <port>
+    @param disk Switch -d <disk>
+    @param reset_type Switch -r <reset_type>
+    @param reset_timeout Switch -R <reset_timeout>
+    @param serial_port Serial port handler, set to None if you want this function to open serial
+
+    @param baudrate Serial port baudrate
+    @param timeout Serial port timeout
+    @param verbose Verbose mode
+    """
+    from serial import Serial
+
+    result = False
+    if not serial_port:
+        try:
+            with Serial(port, baudrate=baudrate, timeout=timeout) as serial_port:
+                result = host_tests_plugins.call_plugin('ResetMethod',
+                                                        reset_type,
+                                                        serial=serial_port,
+                                                        disk=disk)
+            sleep(reset_timeout)
+        except Exception as e:
+            if verbose:
+                print "%s" % (str(e))
+            result = False
+    return result
+
 
 class DefaultTestSelector(DefaultTestSelectorBase):
     """ Select default host_test supervision (replaced after auto detection)

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -134,7 +134,7 @@ def flash_dev(disk=None,
 
 def reset_dev(port=None,
               disk=None,
-              reset_type=None,
+              reset_type='default',
               reset_timeout=1,
               serial_port=None,
               baudrate=9600,

--- a/mbed_host_tests/host_tests_plugins/__init__.py
+++ b/mbed_host_tests/host_tests_plugins/__init__.py
@@ -63,25 +63,27 @@ HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_stlink.load_plugin())
 ###############################################################################
 def call_plugin(type, capability, *args, **kwargs):
     """! Interface to call plugin registry functional way
-
     @param capability Plugin capability we want to call
     @param args Additional parameters passed to plugin
     @param kwargs Additional parameters passed to plugin
-
     @return Returns return value from call_plugin call
     """
     return HOST_TEST_PLUGIN_REGISTRY.call_plugin(type, capability, *args, **kwargs)
 
 def get_plugin_caps(type):
     """! Get list of all capabilities for plugin family with the same type
-
     @param type Type of a plugin
-
     @return Returns list of all capabilities for plugin family with the same type. If there are no capabilities empty list is returned
     """
     return HOST_TEST_PLUGIN_REGISTRY.get_plugin_caps(type)
 
+def get_plugin_info():
+    """! Return plugins information
+    @return Dictionary HOST_TEST_PLUGIN_REGISTRY
+    """
+    return HOST_TEST_PLUGIN_REGISTRY.get_dict()
+
 def print_plugin_info():
-    """ Prints plugins' information in user friendly way
+    """! Prints plugins' information in user friendly way
     """
     print HOST_TEST_PLUGIN_REGISTRY

--- a/mbed_host_tests/host_tests_plugins/host_test_registry.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_registry.py
@@ -57,12 +57,10 @@ class HostTestRegistry:
 
     def call_plugin(self, type, capability, *args, **kwargs):
         """! Execute plugin functionality respectively to its purpose
-
         @param type Plugin type
         @param capability Plugin capability name
         @param args Additional plugin parameters
         @param kwargs Additional plugin parameters
-
         @return Returns result from plugin's execute() method
         """
         for plugin_name in self.PLUGINS:
@@ -73,9 +71,7 @@ class HostTestRegistry:
 
     def get_plugin_caps(self, type):
         """! Returns list of all capabilities for plugin family with the same type
-
         @param type Plugin type
-
         @return Returns list of capabilities for plugin. If there are no capabilities empty list is returned
         """
         result = []
@@ -87,29 +83,45 @@ class HostTestRegistry:
 
     def load_plugin(self, name):
         """! Used to load module from system (by import)
-
         @param name name of the module to import
-
         @return Returns result of __import__ operation
         """
         mod = __import__("module_%s"% name)
         return mod
 
-    def __str__(self):
+    def get_string(self):
         """! User friendly printing method to show hooked plugins
-
         @return Returns string formatted with PrettyTable
         """
         from prettytable import PrettyTable
         column_names = ['name', 'type', 'capabilities', 'stable']
         pt = PrettyTable(column_names)
         for column in column_names:
-            pt.align[column] =  'l'
+            pt.align[column] = 'l'
         for plugin_name in sorted(self.PLUGINS.keys()):
-            name  = self.PLUGINS[plugin_name].name
-            type  = self.PLUGINS[plugin_name].type
+            name = self.PLUGINS[plugin_name].name
+            type = self.PLUGINS[plugin_name].type
             stable = self.PLUGINS[plugin_name].stable
             capabilities  = ', '.join(self.PLUGINS[plugin_name].capabilities)
             row = [name, type, capabilities, stable]
             pt.add_row(row)
         return pt.get_string()
+
+    def get_dict(self):
+        column_names = ['name', 'type', 'capabilities', 'stable']
+        result = {}
+        for plugin_name in sorted(self.PLUGINS.keys()):
+            name = self.PLUGINS[plugin_name].name
+            type = self.PLUGINS[plugin_name].type
+            stable = self.PLUGINS[plugin_name].stable
+            capabilities = self.PLUGINS[plugin_name].capabilities
+            result[plugin_name] = {
+                "name" : name,
+                "type" : type,
+                "stable" : stable,
+                "capabilities" : capabilities
+            }
+        return result
+
+    def __str__(self):
+        return self.get_string()


### PR DESCRIPTION
# Description
This PR is introducing simple Python APIs for flashing and reset. It was originally intended to be used in BLE test framework so branch name is a bit confusing.
This APIs allow test tools developers and others to develop reuse and extend flashing and reset functionality.

Functions added:
```get_host_test_list()``` - Returns list of host test names and its classes
```get_plugin_caps()``` - Returns plugins capabilities
```flash_dev()``` - Flash device with image
```reset_dev()``` - reset device

## Example
Example usage:
```
$ python
>>> import mbed_host_tests
>>> import json
>>> print json.dumps(mbed_host_tests.get_plugin_caps(), indent=4)
{
    "ResetMethod": [
        "default",
        "eACommander",
        "eACommander-usb",
        "stlink"
    ],
    "CopyMethod": [
        "copy",
        "cp",
        "default",
        "eACommander",
        "eACommander-usb",
        "shell",
        "shutil",
        "stlink",
        "xcopy"
    ]
}
>>> mbed_host_tests.flash_dev(disk='E:', image_path=r'c:\Work2\mbed-drivers\build\frdm-k64f-gcc\test\mbed-drivers-test-basic.bin', program_cycle_s=5)
        1 file(s) copied.
True
```
## Changes
* Add functional API to facade flash / reset functionality
* Change in reset_dev API reset_type default value from None to 'default'