### PR TITLE
Add LinuxGeneric value to OS detection function

### DIFF
--- a/mbed_host_tests/host_tests_plugins/host_test_plugins.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_plugins.py
@@ -180,6 +180,8 @@ class HostTestPluginBase:
             result = 'Windows7'
         elif (os_info[0] == 'posix' and os_info[1] == 'Linux' and ('Ubuntu' in os_info[3])):
             result = 'Ubuntu'
+        elif (os_info[0] == 'posix' and os_info[1] == 'Linux'):
+            result = 'LinuxGeneric'
         elif (os_info[0] == 'posix' and os_info[1] == 'Darwin'):
             result = 'Darwin'
         return result

--- a/test/host_test_plugins.py
+++ b/test/host_test_plugins.py
@@ -27,7 +27,7 @@ class HostOSDetectionTestCase(unittest.TestCase):
 
     def setUp(self):
         self.plugin_base = HostTestPluginBase()
-        
+
         pass
 
     def tearDown(self):
@@ -40,7 +40,7 @@ class HostOSDetectionTestCase(unittest.TestCase):
         self.assertNotEqual(None, self.plugin_base.mbed_os_support())
 
     def test_supported_os_name(self):
-        os_names = ['Windows7', 'Ubuntu', 'Darwin']
+        os_names = ['Windows7', 'Ubuntu', 'LinuxGeneric', 'Darwin']
         self.assertIn(self.plugin_base.mbed_os_support(), os_names)
 
     def test_detect_os_support_ext(self):


### PR DESCRIPTION
# Description
Add generic Linux flavor for OS detection function.
It will allow OS detection unit tests to smoothly pass on CircleCI machines.