### PR TITLE
Dynamic host test loader (from directory location)

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -26,13 +26,18 @@ Write your own programs (import this package) or use 'mbedhtrun' command line to
 """
 
 import sys
+import imp
 import json
+import inspect
+from os import listdir
+from os.path import isfile, join, abspath
 from time import sleep
 from optparse import OptionParser
 
 import host_tests_plugins
 from host_tests_registry import HostRegistry
 from host_tests import BaseHostTest
+
 
 # Host test supervisors
 from host_tests.echo import EchoTest
@@ -169,6 +174,35 @@ def reset_dev(port=None,
             result = False
     return result
 
+def enum_host_tests(path, verbose=False):
+    """ Enumerates and registers locally stored host tests
+        Host test are derived from mbed_host_tests.BaseHostTest classes
+    """
+    if verbose:
+        print "HOST: Inspecting '%s' for local host tests..."% abspath(path)
+
+    # Listing Python tiles within path directory
+    host_tests_list = [f for f in listdir(path) if isfile(join(path, f))]
+    for ht in host_tests_list:
+        if ht.endswith(".py"):
+            abs_path = abspath(join(path, ht))
+            mod = imp.load_source(ht[:-3], abs_path)
+            if verbose:
+                print "HOST: Loading module '%s': "% (ht), str(mod)
+
+            for mod_name, mod_obj in inspect.getmembers(mod):
+                if inspect.isclass(mod_obj):
+                    #if verbose:
+                    #    print 'HOST: Class found:', str(mod_obj), type(mod_obj)
+                    if issubclass(mod_obj, BaseHostTest) and str(mod_obj) != str(BaseHostTest):
+                        host_test_name = ht[:-3]
+                        if mod_obj.name:
+                            host_test_name = mod_obj.name
+                        host_test_cls = mod_obj
+                        if verbose:
+                            print "HOST: Found host test implementation: %s -|> %s"% (str(mod_obj), str(BaseHostTest))
+                            print "HOST: Registering '%s' as '%s'"% (str(host_test_cls), host_test_name)
+                        HOSTREGISTRY.register_host_test(host_test_name, host_test_cls())
 
 class DefaultTestSelector(DefaultTestSelectorBase):
     """ Select default host_test supervision (replaced after auto detection)
@@ -182,6 +216,11 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         # Handle extra command from
         if options:
+
+            if options.enum_host_tests:
+                path = self.options.enum_host_tests
+                enum_host_tests(path, verbose=options.verbose)
+
             if options.list_reg_hts:    # --list option
                 self.print_ht_list()
                 sys.exit(0)
@@ -479,6 +518,10 @@ def init_host_test_cli_params():
                       metavar="NUMBER",
                       type="int",
                       help="When forcing a reset using option -r you can set up after reset idle delay in seconds")
+
+    parser.add_option("-e", "--enum-host-tests",
+                      dest="enum_host_tests",
+                      help="Define directory with local host tests")
 
     parser.add_option('', '--test-cfg',
                       dest='json_test_configuration',

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -32,6 +32,7 @@ from optparse import OptionParser
 
 import host_tests_plugins
 from host_tests_registry import HostRegistry
+from host_tests import BaseHostTest
 
 # Host test supervisors
 from host_tests.echo import EchoTest

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -20,6 +20,8 @@ class BaseHostTest():
         rampUp, test and rampDown set of functions
     """
 
+    name = ''   # name of the host test (used for local registration)
+
     def rumpUp(self):
         """ Ramp up function, initialize your test case dynamic resources in this function
         """


### PR DESCRIPTION
# Description
This feature allows ```mbedhtrun``` to load and register additional host test scripts from given directory.

In many cases users will add host tests to their yotta modules preferably under ```/test/host_tests/```module directory.

Host tests script files are enumerated and registered so they can be used with local module test cases.
# Rationale
Not all host tests can be stored with ```mbedhtrun``` package. Some of them may and will be only used locally, for prototyping. Some host tests may just be very module dependent and should not be stored with ``mbedhtrun```. 

## Switch -e (enumerate host tests from directory)
New CLI switch ```-e``` / ```--enum-host-tests``` defines (yotta module) directory in which we will store local host tests. You can also point ```mbedhtrun``` to different directory with pool of host tests.

**Note**: Directory ytmodule```/test/host_tests``` will be default local host test location used by test tools such as ```greentea```.

## Example
In this example we have simple test ```basic``` located under ```/test/basic``` (C++ code) and corresponding host test under ```/test/host_tests```,

In this example we will add to yotta module ```./test``` directory sub directory ```host_tests``` and put simple host test ```basic.py```.

Test ```/test/basic``` is connected with host test by name ```mbed_drivers_basic``` defined both in test case C++ source code (see listing below) and as name of host test.

Directory structure with local host test(s):
```
ytmodule
├───test
...
│   ├───host_tests
│       ├───basic.py
```
We can now point ```mbedhtrun``` (switch ```--enum-host-tests .\test\host_tests\```) to new location within yotta module and use ```--list``` switch to just registered host tests:
```
$ cd ytmodule
$ mbedhtrun --enum-host-tests .\test\host_tests\ --list
```
```
'default'                : mbed_host_tests.host_tests.default_auto.DefaultAuto()
'default_auto'           : mbed_host_tests.host_tests.default_auto.DefaultAuto()
'detect_auto'            : mbed_host_tests.host_tests.detect_auto.DetectPlatformTest()
'dev_null_auto'          : mbed_host_tests.host_tests.dev_null_auto.DevNullTest()
'echo'                   : mbed_host_tests.host_tests.echo.EchoTest()
'hello_auto'             : mbed_host_tests.host_tests.hello_auto.HelloTest()
'mbed_client_auto'       : mbed_host_tests.host_tests.mbed_client_auto.LWM2MClientAutoTest()
'mbed_drivers_basic'     : basic.Basic()
...
```
New locally defined host test was registered as ```mbed_drivers_basic``` (module ```basic```, class ```basic.Basic()```.
Where:
* ```mbed_drivers_basic``` is host test name loaded from ```BaseHostTest.Basic.name```
* module ```basic``` name is Python file name (no extension)
* class ```basic.Basic()``` name is composed from module and class (inherited from ```BaseHostTest```) name inside host test file

## Example test (+ new host test) execution command
```
$ mbedhtrun -d F: -p COM172 -f "/path/to/basic.bin" -C 4 -c shell -m K64F -e ./test/host_tests
```
**Note**: Add switch ```-v``` to increase ```-e```  switch's verboseness. 
### basic.cpp listing
```c++
#include "mbed-drivers/test_env.h"

void runTest() {
    MBED_HOSTTEST_TIMEOUT(20);
    MBED_HOSTTEST_SELECT(mbed_drivers_basic);
    MBED_HOSTTEST_DESCRIPTION(Basic);
    MBED_HOSTTEST_START("MBED_A1");
    MBED_HOSTTEST_RESULT(true);
}

void app_start(int, char*[]) {
    minar::Scheduler::postCallback(&runTest);
}
```
**Note**: ```MBED_HOSTTEST_SELECT(mbed_drivers_basic);``` macro usage.

### basic.py listing
```python
from mbed_host_tests import BaseHostTest

class Basic(BaseHostTest):
    """ Simple, basic host test's test runner waiting for serial port
        output from MUT, no supervision over test running in MUT is executed.
    """

    name = 'mbed_drivers_basic'

    def test(self, selftest):
        result = selftest.RESULT_SUCCESS
        # test case implementation
        return result
```
**Note**: ```name = 'mbed_drivers_basic'``` host test name definition.
