### PR TITLE
Support for pyserial 3.0

### DIFF
--- a/mbed_host_tests/host_tests_plugins/module_reset_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_reset_mbed.py
@@ -83,10 +83,7 @@ class HostTestPluginResetMethod_Mbed(HostTestPluginBase):
         except:
             # In Linux a termios.error is raised in sendBreak and in setBreak.
             # The following break_condition = False is needed to release the reset signal on the target mcu.
-            try:
-                serial.break_condition = False
-            except:
-                result = False
+            serial.break_condition = False
         return result
 
     # Plugin interface

--- a/test/host_registry.py
+++ b/test/host_registry.py
@@ -37,7 +37,7 @@ class HostRegistryTestCase(unittest.TestCase):
     def test_register_host_test(self):
         self.HOSTREGISTRY.register_host_test('host_test_mock_auto', HostTestClassMock())
         self.assertEqual(True, self.HOSTREGISTRY.is_host_test('host_test_mock_auto'))
-        
+
     def test_unregister_host_test(self):
         self.HOSTREGISTRY.register_host_test('host_test_mock_2_auto', HostTestClassMock())
         self.assertEqual(True, self.HOSTREGISTRY.is_host_test('host_test_mock_2_auto'))
@@ -59,6 +59,11 @@ class HostRegistryTestCase(unittest.TestCase):
         for ht_name in self.HOSTREGISTRY.HOST_TESTS:
             ht = self.HOSTREGISTRY.HOST_TESTS[ht_name]
             self.assertNotEqual(None, ht)
+
+    def test_host_test_has_name_attribute(self):
+        for ht_name in self.HOSTREGISTRY.HOST_TESTS:
+            ht = self.HOSTREGISTRY.HOST_TESTS[ht_name]
+            self.assertTrue(hasattr(ht, 'test'))
 
 
 if __name__ == '__main__':

--- a/test/host_test_plugins.py
+++ b/test/host_test_plugins.py
@@ -19,8 +19,10 @@ limitations under the License.
 import unittest
 
 import os
+import re
 import sys
 import platform
+import pkg_resources
 from mbed_host_tests.host_tests_plugins.host_test_plugins import HostTestPluginBase
 
 class HostOSDetectionTestCase(unittest.TestCase):
@@ -28,6 +30,7 @@ class HostOSDetectionTestCase(unittest.TestCase):
     def setUp(self):
         self.plugin_base = HostTestPluginBase()
         self.os_names = ['Windows7', 'Ubuntu', 'LinuxGeneric', 'Darwin']
+        self.re_float = re.compile("^\d+\.\d+$")
 
     def tearDown(self):
         pass
@@ -49,6 +52,14 @@ class HostOSDetectionTestCase(unittest.TestCase):
                    sys.platform)
 
         self.assertEqual(os_info, self.plugin_base.mbed_os_info())
+
+    def test_pyserial_version_as_float(self):
+        pyserial_version = pkg_resources.require("pyserial")[0].version
+        # We want to make sure pyserial version is a parsabl;e float
+        # Because we are using float(version) conversion to check version
+        # of this module
+        self.assertTrue(self.re_float.findall(pyserial_version))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/host_test_plugins.py
+++ b/test/host_test_plugins.py
@@ -27,8 +27,7 @@ class HostOSDetectionTestCase(unittest.TestCase):
 
     def setUp(self):
         self.plugin_base = HostTestPluginBase()
-
-        pass
+        self.os_names = ['Windows7', 'Ubuntu', 'LinuxGeneric', 'Darwin']
 
     def tearDown(self):
         pass
@@ -40,8 +39,7 @@ class HostOSDetectionTestCase(unittest.TestCase):
         self.assertNotEqual(None, self.plugin_base.mbed_os_support())
 
     def test_supported_os_name(self):
-        os_names = ['Windows7', 'Ubuntu', 'LinuxGeneric', 'Darwin']
-        self.assertIn(self.plugin_base.mbed_os_support(), os_names)
+        self.assertIn(self.plugin_base.mbed_os_support(), self.os_names)
 
     def test_detect_os_support_ext(self):
         os_info = (os.name,


### PR DESCRIPTION
Below API is deprecated for pyserial 3.x versions!
* http://pyserial.readthedocs.org/en/latest/pyserial_api.html#serial.Serial.sendBreak
* http://pyserial.readthedocs.org/en/latest/pyserial_api.html#serial.Serial.setBreak

See:
* http://pyserial.readthedocs.org/en/latest/pyserial_api.html#serial.Serial.send_break
* http://pyserial.readthedocs.org/en/latest/pyserial_api.html#serial.Serial.break_condition

Note: **For send break to work** we need to make sure your DAPlink (Interface firmware) **version is >= 0226**.