### PR TITLE
Add PID print

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -225,7 +225,6 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         # Handle extra command from
         if options:
-
             if options.enum_host_tests:
                 path = self.options.enum_host_tests
                 enum_host_tests(path, verbose=options.verbose)
@@ -342,9 +341,10 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
     def run(self):
         """! This function will perform extra setup and proceed with test selector's work flow
-
         @details This function will call execute() but first will call setup() to perform extra actions
         """
+        print "HOST: My PID is %d"% os.getpid()
+
         self.setup()    # Additional setup (optional before execute() call)
 
         if self.mbed.options:

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -57,7 +57,7 @@ class Mbed:
 
         # Users can use command to pass port speeds together with port name. E.g. COM4:115200:1
         # Format if PORT:SPEED:TIMEOUT
-        port_config = self.port.split(':')
+        port_config = self.port.split(':') if self.port else ''
         if len(port_config) == 2:
             # -p COM4:115200
             self.port = port_config[0]
@@ -83,7 +83,7 @@ class Mbed:
                 print "MBED: Test configuration JSON Unexpected error:"
                 raise
 
-        print 'MBED: Instrumentation: "%s" and disk: "%s"' % (self.port, self.disk)
+        print 'HOST: Instrumentation: "%s" and disk: "%s"' % (self.port, self.disk)
 
     def init_serial_params(self, serial_baud=115200, serial_timeout=1):
         """! Initialize port parameters.


### PR DESCRIPTION
* Small change in host print regarding port/disk settings and PID:
```
$ mbedhtrun
mbedhtrun
HOST: Instrumentation: "None" and disk: "None"
HOST: My PID is 10332
...
```
**Note**: It should be easier to kill this process in the future knowing its PID from the beginning.

* Fixed not handled serial port parameter parsing:
```
$ mbedhtrun
Traceback (most recent call last):
  File "C:\Python27\Scripts\mbedhtrun-script.py", line 9, in <module>
    load_entry_point('mbed-host-tests', 'console_scripts', 'mbedhtrun')()
  File "c:\work\pypi\htrun\mbed_host_tests\mbedhtrun.py", line 29, in main
    test_selector = DefaultTestSelector(init_host_test_cli_params())
  File "c:\work\pypi\htrun\mbed_host_tests\__init__.py", line 254, in __init__
    DefaultTestSelectorBase.__init__(self, options)
  File "c:\work\pypi\htrun\mbed_host_tests\host_tests_runner\host_test.py", line 216, in __init__
    Test.__init__(self, options=options)
  File "c:\work\pypi\htrun\mbed_host_tests\host_tests_runner\host_test.py", line 50, in __init__
    self.mbed = Mbed(options)
  File "c:\work\pypi\htrun\mbed_host_tests\host_tests_runner\mbed_base.py", line 60, in __init__
    port_config = self.port.split(':')
AttributeError: 'NoneType' object has no attribute 'split'
```