### PR TITLE
Aborting mechanism when parent process wants to stop mbedhtrun

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -512,12 +512,9 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         self.notify("HOST: Aborted by parent process!")
         self.aborted = True
         try:
-            if self.test_supervisor is not None and 'abort' in dir(self.test_supervisor) and \
-                    callable(getattr(self.test_supervisor, 'abort')):
-                self.test_supervisor.abort()
+            self.test_supervisor.rampDown()
         finally:
-            pass
-        self.finish()
+            self.finish()
 
 
 def init_host_test_cli_params():

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -213,6 +213,7 @@ def enum_host_tests(path, verbose=False):
                                     print "HOST: Registering '%s' as '%s'"% (str(host_test_cls), host_test_name)
                                 HOSTREGISTRY.register_host_test(host_test_name, host_test_cls())
 
+
 class DefaultTestSelector(DefaultTestSelectorBase):
     """ Select default host_test supervision (replaced after auto detection)
     """
@@ -252,6 +253,11 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 sys.exit(0)
 
         DefaultTestSelectorBase.__init__(self, options)
+
+        # Following flag is to indicate to this selector that parent process wants it to abort.
+        # It would to set by self.abort() by parent_monitor_thread() thread in mbedhtrun.py.
+        # Since this selector does not employ a loop and immediate exit is not necessary we don't need locking around it
+        self.aborted = False
 
     def print_ht_list(self):
         """! Prints list of registered host test classes (by name)
@@ -345,8 +351,12 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         @details This function will call execute() but first will call setup() to perform extra actions
         """
+        if self.aborted:
+            return
         self.setup()    # Additional setup (optional before execute() call)
 
+        if self.aborted:
+            return
         if self.mbed.options:
             # We would like to run some binaries, not as tests but as examples, demos etc.
             # In this case we will use host-tests to just print console output
@@ -354,6 +364,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 self.execute_run()
                 return
         # Normal host test path: flash, reset, host test execution, grab test results, end
+        if self.aborted:
+            return
         self.execute()
 
     def execute_run(self):
@@ -365,6 +377,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         @details This feature is sensitive for flags such as --skip-reset or --skip-flashing
         """
+        if self.aborted:
+            return
         # Copy image to device
         if self.options.skip_flashing is False:
             self.notify("HOST: Copy image onto target...")
@@ -374,12 +388,16 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         else:
             self.notify("HOST: Image copy onto target SKIPPED!")
 
+        if self.aborted:
+            return
         # Initialize and open target's serial port (console)
         self.notify("HOST: Initialize serial port...")
         result = self.mbed.init_serial()
         if not result:
             self.print_result(self.RESULT_IO_SERIAL)
 
+        if self.aborted:
+            return
         # Reset device
         if self.options.skip_reset is False:
             self.notify("HOST: Reset target...")
@@ -391,6 +409,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         # Run binary and grab and print console output
         # Read serial and wait for binary execution end
+        if self.aborted:
+            return
         try:
             self.test_supervisor = get_host_test("run_binary_auto")
             # Call to rampUp if function is implemented
@@ -423,6 +443,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                  and test execution timeout will be measured.
         """
         # Copy image to device
+        if self.aborted:
+            return
         if self.options.skip_flashing is False:
             self.notify("HOST: Copy image onto target...")
             result = self.mbed.copy_image()
@@ -432,6 +454,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         else:
             self.notify("HOST: Copy image onto target... SKIPPED!")
 
+        if self.aborted:
+            return
         # Initialize and open target's serial port (console)
         self.notify("HOST: Initialize serial port...")
         result = self.mbed.init_serial()
@@ -439,6 +463,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             self.print_result(self.RESULT_IO_SERIAL)
             return  # No need to continue, we can't open serial port
 
+        if self.aborted:
+            return
         # Reset device
         if self.options.skip_reset is False:
             self.notify("HOST: Reset target...")
@@ -450,6 +476,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             self.notify("HOST: Reset target... SKIPPED!")
 
         # Run test
+        if self.aborted:
+            return
         try:
             CONFIG = self.detect_test_config(verbose=True) # print CONFIG
 
@@ -474,6 +502,23 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         except Exception, e:
             print str(e)
             self.print_result(self.RESULT_ERROR)
+
+    def abort(self):
+        """
+        Handler for abort instruction from mbed greentea.
+
+        :return:
+        """
+        self.notify("HOST: Aborted by parent process!")
+        self.aborted = True
+        try:
+            if self.test_supervisor is not None and 'abort' in dir(self.test_supervisor) and \
+                    callable(getattr(self.test_supervisor, 'abort')):
+                self.test_supervisor.abort()
+        finally:
+            pass
+        self.finish()
+
 
 def init_host_test_cli_params():
     """! Function creates CLI parser object and returns populated options object.

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -40,3 +40,11 @@ class BaseHostTest():
         """ Ramp up function, free your test case dynamic resources in this function
         """
         pass
+
+    def abort(self):
+        """
+        Called by selector to abort the test. Test case should implement any necessary cleanup required to unblock the
+         selector to stop. Test Cases do not need to implement this if there is nothing blocking in the test.
+        :return:
+        """
+        pass

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -40,11 +40,3 @@ class BaseHostTest():
         """ Ramp up function, free your test case dynamic resources in this function
         """
         pass
-
-    def abort(self):
-        """
-        Called by selector to abort the test. Test case should implement any necessary cleanup required to unblock the
-         selector to stop. Test Cases do not need to implement this if there is nothing blocking in the test.
-        :return:
-        """
-        pass

--- a/mbed_host_tests/mbedhtrun.py
+++ b/mbed_host_tests/mbedhtrun.py
@@ -46,8 +46,9 @@ def main():
     """
     test_selector = DefaultTestSelector(init_host_test_cli_params())
     try:
-        t = threading.Thread(target=parent_monitor_thread, args=(test_selector,))
-        t.start()   # This thread will shutdown automatically after stdin is closed on returning from main()
+        if not sys.stdin.isatty(): # Only monitor stdin if started from a parent process.
+            t = threading.Thread(target=parent_monitor_thread, args=(test_selector,))
+            t.start()   # This thread will shutdown automatically after stdin is closed on returning from main()
         test_selector.run()
     except (KeyboardInterrupt, SystemExit):
         test_selector.finish()

--- a/mbed_host_tests/mbedhtrun.py
+++ b/mbed_host_tests/mbedhtrun.py
@@ -32,8 +32,11 @@ def parent_monitor_thread(selector):
     :return:
     """
     while True:
-        c = sys.stdin.read(1)
-        if c is None or len(c) == 0:
+        try:
+            c = sys.stdin.read(1)
+            if c is None or len(c) == 0:    # read returns None or empty string when stdin is closed.
+                break
+        except IOError:     # Error on pipe should have same behavior as stdin close.
             break
     selector.abort()    # Tell selector to abort
 

--- a/mbed_host_tests/mbedhtrun.py
+++ b/mbed_host_tests/mbedhtrun.py
@@ -17,8 +17,26 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
+import sys
+import threading
 from mbed_host_tests import DefaultTestSelector         # Default adapter for DefaultTestSelectorBase
 from mbed_host_tests import init_host_test_cli_params   # Provided command line options
+
+
+def parent_monitor_thread(selector):
+    """
+    Monitors that parent is still connected to the child via stdin pipe. When pipe is disconnected assumes that parent
+    wants it to exit. Example: in timeout situations.
+
+    :param selector:
+    :return:
+    """
+    while True:
+        c = sys.stdin.read(1)
+        if c is None or len(c) == 0:
+            break
+    selector.abort()    # Tell selector to abort
+
 
 def main():
     """! This function drives command line tool 'mbedhtrun' which is using DefaultTestSelector
@@ -28,6 +46,8 @@ def main():
     """
     test_selector = DefaultTestSelector(init_host_test_cli_params())
     try:
+        t = threading.Thread(target=parent_monitor_thread, args=(test_selector,))
+        t.start()   # This thread will shutdown automatically after stdin is closed on returning from main()
         test_selector.run()
     except (KeyboardInterrupt, SystemExit):
         test_selector.finish()


### PR DESCRIPTION
Fix for issue https://github.com/ARMmbed/greentea/issues/48

Changes:
 - Added a stdin monitoring thread
 - Aborting selector when stdin is closed.
 - Check for abort at different steps of execution.
 - Selector aborts test case.
 - Added new based class method abort().

Creating PR for feedback from issue creator. Unit tests will be added soon.

This PR is complimentary to https://github.com/ARMmbed/greentea/pull/63 (they should come at the same time in release.