### PR TITLE
Event handler decorator for automatic registering of event callbacks

### DIFF
--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -81,7 +81,7 @@ class BaseHostTestAbstract(object):
         raise NotImplementedError
 
 
-def event_cb(key):
+def event_callback(key):
     """
     Decorator for defining a event callback method. Adds a property attribute "event_key" with value as the passed key.
 
@@ -117,6 +117,7 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         ]
 
         self.__assign_default_callbacks()
+        self.__assign_decorated_callbacks()
 
     def __callback_default(self, key, value, timestamp):
         """! Default callback """
@@ -127,6 +128,24 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         """! Assigns default callback handlers """
         for key in self.__consume_by_default:
             self.__callbacks[key] = self.__callback_default
+
+    def __assign_decorated_callbacks(self):
+        """
+        It looks for any callback methods decorated with @event_callback
+
+        Example:
+        Define a method with @event_callback decorator like:
+
+         @event_callback('<event key>')
+         def event_handler(self, key, value, timestamp):
+            do something..
+
+        :return:
+        """
+        for name, method in inspect.getmembers(self, inspect.ismethod):
+            key = getattr(method, 'event_key', None)
+            if key:
+                self.register_callback(key, method)
 
     def register_callback(self, key, callback, force=False):
         """! Register callback for a specific event (key: event name)
@@ -175,23 +194,7 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         return self.__callbacks
 
     def setup(self):
-        """
-        Base implementation of test setup. It looks for methods decorated with decorator @event_cb and
-        registers them as event callbacks.
-
-        Example:
-        Define a method with @event_cb decorator like:
-
-         @event_cb('<event key>')
-         def event_handler(self, key, value, timestamp):
-            do something..
-
-        :return:
-        """
-        for name, method in inspect.getmembers(self, inspect.ismethod):
-            key = getattr(method, 'event_key', None)
-            if key:
-                self.register_callback(key, method)
+        pass
 
     def result(self):
         pass

--- a/test/event_callback_decorator.py
+++ b/test/event_callback_decorator.py
@@ -1,0 +1,41 @@
+# Copyright 2015 ARM Limited, All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from mbed_host_tests.host_tests.base_host_test import BaseHostTest, event_cb
+
+
+class TestEvenCallbackDecorator(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_event_callback_decorator(self):
+        class Ht(BaseHostTest):
+
+            @event_cb('Hi')
+            def hi(self, key, value, timestamp):
+                print 'hi'
+
+            @event_cb('Hello')
+            def hello(self, key, value, timestamp):
+                print 'hello'
+        h = Ht()
+        h.setup()
+        callbacks = h.get_callbacks()
+        self.assertIn('Hi', callbacks)
+        self.assertIn('Hello', callbacks)

--- a/test/event_callback_decorator.py
+++ b/test/event_callback_decorator.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from mbed_host_tests.host_tests.base_host_test import BaseHostTest, event_cb
+from mbed_host_tests.host_tests.base_host_test import BaseHostTest, event_callback
 
 
 class TestEvenCallbackDecorator(unittest.TestCase):
@@ -27,11 +27,11 @@ class TestEvenCallbackDecorator(unittest.TestCase):
     def test_event_callback_decorator(self):
         class Ht(BaseHostTest):
 
-            @event_cb('Hi')
+            @event_callback('Hi')
             def hi(self, key, value, timestamp):
                 print 'hi'
 
-            @event_cb('Hello')
+            @event_callback('Hello')
             def hello(self, key, value, timestamp):
                 print 'hello'
         h = Ht()


### PR DESCRIPTION
This is an alternative approach to implementing ```setup``` method and calling ```self.register_callback``` for registering event callbacks. 
Now event callbacks can be decorated with a decorator as ```@event_cb('<key>')```. A base implementation of ```setup``` is added in the ```BaseHostTest``` to look for decorated methods and register them as callbacks. Thus host test developers do not need to implement ```setup``` anymore. 

```
Example:
 #        Define a event callback method with @event_callback decorator like:
 
          @event_callback('<event key>')
          def event_handler(self, key, value, timestamp):
             do something..
 
```