### PR TITLE
Default handling for 'end' event

### DIFF
--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -117,12 +117,28 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         ]
 
         self.__assign_default_callbacks()
+        # Register default handler for event 'end' before assigning user defined callbacks to let users over write it.
+        self.register_callback('end', self.default_end_callback)
         self.__assign_decorated_callbacks()
 
     def __callback_default(self, key, value, timestamp):
         """! Default callback """
         #self.log("CALLBACK: key=%s, value=%s, timestamp=%f"% (key, value, timestamp))
         pass
+
+    def default_end_callback(self, key, value, timestamp):
+        """
+        Default handler for event 'end' that gives test result from target.
+        This callback is not decorated as we don't know then in what order this
+        callback would be registered. We want to let users over write this callback.
+        Hence it should be registered before registering user defined callbacks.
+
+        :param key:
+        :param value:
+        :param timestamp:
+        :return:
+        """
+        self.notify_complete(value == 'success')
 
     def __assign_default_callbacks(self):
         """! Assigns default callback handlers """

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -118,7 +118,7 @@ class HostTestCallbackBase(BaseHostTestAbstract):
 
         self.__assign_default_callbacks()
         # Register default handler for event 'end' before assigning user defined callbacks to let users over write it.
-        self.register_callback('end', self.default_end_callback)
+        self.register_callback('end', self.__default_end_callback)
         self.__assign_decorated_callbacks()
 
     def __callback_default(self, key, value, timestamp):
@@ -126,7 +126,7 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         #self.log("CALLBACK: key=%s, value=%s, timestamp=%f"% (key, value, timestamp))
         pass
 
-    def default_end_callback(self, key, value, timestamp):
+    def __default_end_callback(self, key, value, timestamp):
         """
         Default handler for event 'end' that gives test result from target.
         This callback is not decorated as we don't know then in what order this

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -117,8 +117,6 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         ]
 
         self.__assign_default_callbacks()
-        # Register default handler for event 'end' before assigning user defined callbacks to let users over write it.
-        self.register_callback('end', self.__default_end_callback)
         self.__assign_decorated_callbacks()
 
     def __callback_default(self, key, value, timestamp):
@@ -144,6 +142,8 @@ class HostTestCallbackBase(BaseHostTestAbstract):
         """! Assigns default callback handlers """
         for key in self.__consume_by_default:
             self.__callbacks[key] = self.__callback_default
+        # Register default handler for event 'end' before assigning user defined callbacks to let users over write it.
+        self.register_callback('end', self.__default_end_callback)
 
     def __assign_decorated_callbacks(self):
         """

--- a/mbed_host_tests/host_tests/default_auto.py
+++ b/mbed_host_tests/host_tests/default_auto.py
@@ -23,17 +23,4 @@ class DefaultAuto(BaseHostTest):
     """ Simple, basic host test's test runner waiting for serial port
         output from MUT, no supervision over test running in MUT is executed.
     """
-
-    __result = None
-
-    def _callback_end(self, key, value, timeout):
-        self.notify_complete(value == 'success')
-
-    def setup(self):
-        self.register_callback('end', self._callback_end)
-
-    def result(self):
-        return self.__result
-
-    def teardown(self):
-        pass
+    pass


### PR DESCRIPTION
For most cases event 'end' callback has following handling:

```python
def end_event_callback(self, key, value, timestamp):
    self.notify_complete(value == 'success')
```

Hence this PR implements a default callback with above handling in base ```class HostTestCallbackBase```.
Users can still over write this handler by creating a handler and registering for key 'end'. Example:

```python
def my_end_callback(self, key, value, timestamp):
    # my implementation for 'end' handling
    ....
```
