### PR TITLE
exporting event_callback up to be imported from mbed_host_tests

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -37,7 +37,7 @@ from optparse import OptionParser
 
 from mbed_host_tests import host_tests_plugins
 from mbed_host_tests.host_tests_registry import HostRegistry
-from mbed_host_tests.host_tests import BaseHostTest
+from mbed_host_tests.host_tests import BaseHostTest, event_callback
 
 # Host test supervisors
 from  mbed_host_tests.host_tests.echo import EchoTest

--- a/mbed_host_tests/host_tests/__init__.py
+++ b/mbed_host_tests/host_tests/__init__.py
@@ -16,4 +16,4 @@ limitations under the License.
 """
 
 # base host test class
-from base_host_test import BaseHostTest
+from base_host_test import BaseHostTest, event_callback


### PR DESCRIPTION
base class ```BaseHostTest``` can be exported from mbed_host_tests module. Now ```event_callback``` decorator can also be imported with ```BaseHostTest```