### PR TITLE
Add greentea-client version in preamble detection

### DIFF
--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -95,6 +95,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         callbacks__exit = False
         # Handle to dynamically loaded host test object
         self.test_supervisor = None
+        # Version: greentea-client version from DUT
+        self.client_version = None
 
         config = {
             "digest" : "serial",
@@ -129,6 +131,9 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             start_time = time()
                             timeout_duration = int(value) # New timeout
                             self.logger.prn_inf("setting timeout to: %d sec"% int(value))
+                        elif key == '__version':
+                            self.client_version = value
+                            self.logger.prn_inf("DUT greentea-client version: " + self.client_version)
                         elif key == '__host_test_name':
                             # Load dynamically requested host test
                             self.test_supervisor = get_host_test(value)


### PR DESCRIPTION
# Changes
* Add new event ```__version``` to send ```greentea-client``` version to host from DUT.
* Handled in preamble.

```
[1457397994.44][HTST][INF] DUT greentea-client version: 0.1.7
[1457397994.44][CONN][RXD] {{__version;0.1.7}}
```

# Example
```
[1457397984.11][HTST][INF] copy image onto target...
Liczba skopiowanych plików:         1.
[1457397992.67][HTST][INF] starting host test process...
[1457397993.03][CONN][INF] starting connection process...
[1457397993.03][CONN][INF] initializing serial port listener...
[1457397993.03][SERI][INF] serial(port=COM10, baudrate=9600)
[1457397993.03][SERI][INF] reset device using 'default' plugin...
[1457397993.28][SERI][INF] wait for it...
[1457397994.28][CONN][INF] sending preamble 'e5743557-e3a5-484e-97da-b83c3f8bfb67'...
[1457397994.28][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1457397994.28][SERI][TXD] {{__sync;e5743557-e3a5-484e-97da-b83c3f8bfb67}}
[1457397994.41][CONN][INF] found SYNC in stream: {{__sync;e5743557-e3a5-484e-97da-b83c3f8bfb67}}, queued...
[1457397994.41][HTST][INF] sync KV found, uuid=e5743557-e3a5-484e-97da-b83c3f8bfb67, timestamp=1457397994.409000
[1457397994.42][CONN][RXD] {{__sync;e5743557-e3a5-484e-97da-b83c3f8bfb67}}
[1457397994.44][CONN][INF] found KV pair in stream: {{__version;0.1.7}}, queued...
[1457397994.44][HTST][INF] DUT greentea-client version: 0.1.7
[1457397994.44][CONN][RXD] {{__version;0.1.7}}
[1457397994.45][CONN][INF] found KV pair in stream: {{__timeout;5}}, queued...
[1457397994.45][HTST][INF] setting timeout to: 5 sec
[1457397994.45][CONN][RXD] {{__timeout;5}}
[1457397994.49][CONN][INF] found KV pair in stream: {{__host_test_name;default_auto}}, queued...
[1457397994.49][HTST][INF] host test setup() call...
```