### PR TITLE
Add support for when a program which uses multiprocessing has been frozen

### DIFF
--- a/mbed_host_tests/mbedhtrun.py
+++ b/mbed_host_tests/mbedhtrun.py
@@ -17,6 +17,7 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
+from multiprocessing import freeze_support
 from mbed_host_tests import init_host_test_cli_params
 from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
 
@@ -26,6 +27,7 @@ def main():
     @details 1. Create DefaultTestSelector object and pass command line parameters
              2. Call default test execution function run() to start test instrumentation
     """
+    freeze_support()
     result = -2
     test_selector = DefaultTestSelector(init_host_test_cli_params())
     try:


### PR DESCRIPTION
Add support for when a program which uses multiprocessing has been frozen to produce a Windows executable.

See here: https://docs.python.org/2/library/multiprocessing.html#multiprocessing.freeze_support

This may cause some RuntimeErrors like:
```
    self._popen = Popen(self)
  File "c:\Python27.11\lib\multiprocessing\process.py", line 130, in start
      File "c:\Python27.11\lib\multiprocessing\forking.py", line 258, in __init__
self._popen = Popen(self)
  File "c:\Python27.11\lib\multiprocessing\forking.py", line 258, in __init__
    cmd = get_command_line() + [rhandle]
      File "c:\Python27.11\lib\multiprocessing\forking.py", line 358, in get_command_line
cmd = get_command_line() + [rhandle]
  File "c:\Python27.11\lib\multiprocessing\forking.py", line 358, in get_command_line
    is not going to be frozen to produce a Windows executable.''')
RuntimeError:
is not going to be frozen to produce a Windows executable.''')
            Attempt to start a new process before the current process
            has finished its bootstrapping phase.
RuntimeError
            This probably means that you are on Windows and you have
            forgotten to use the proper idiom in the main module:

                if __name__ == '__main__':
                    freeze_support()
                    ...
:
            The "freeze_support()" line can be omitted if the program
            is not going to be frozen to produce a Windows executable.

            Attempt to start a new process before the current process
            has finished its bootstrapping phase.
```
