### PR TITLE
Changes to support DUT reset in a test

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -168,6 +168,11 @@ def init_host_test_cli_params():
                       help="Target disk (mount point) path",
                       metavar="DISK_PATH")
 
+    parser.add_option("-t", "--target-id",
+                      dest="target_id",
+                      help="Unique Target Id or mbed platform",
+                      metavar="TARGET_ID")
+
     parser.add_option("-f", "--image-path",
                       dest="image_path",
                       help="Path with target's binary image",

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -49,6 +49,14 @@ class BaseHostTestAbstract(object):
         if self.__event_queue:
             self.__event_queue.put(('__notify_complete', result, time()))
 
+    def reset_dut(self):
+        """
+        Reset device under test
+        :return:
+        """
+        if self.__event_queue:
+            self.__event_queue.put(('__reset_dut', True, time()))
+
     def notify_conn_lost(self, text):
         """! Notify main even loop that there was a DUT-host test connection error
         @param consume If True htrun will process (consume) all remaining events

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -193,7 +193,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             # Disconnecting and re-connecting comm process will reset DUT
                             dut_event_queue.put(('__host_test_finished', True, time()))
                             p.join()
-                            self.mbed.update_device_info()
+                            # self.mbed.update_device_info() - This call is commented but left as it would be required in hard reset.
                             p = start_conn_process()
                         elif key == '__notify_conn_lost':
                             # This event is sent by conn_process, DUT connection was lost


### PR DESCRIPTION
- Support to reset DUT in test.
- Now greentea will provide mbed platform's unique target id to confirm same device is used after reset.

Please see following sequence diagram that illustrates how a test can manage its state before a after restart:

```
DUT                     host
---                     ----
 |    {{__sync;UUID}}     |
 |<-----------------------|
 |                        |
 |    {{__sync;UUID}}     |
 |----------------------->|

 - - - - - - - - - - -  - -
        HANDSHAKE !
 - - - - - - - - - - -  - -

 |                        |
 |   {{__timeout;%s}}     |
 |----------------------->|
 |                        |
 |{{__host_test_name;%s}} |
 |----------------------->|

 - - - - - - - - - - -  - -
 TEST SUITE CONTROL UNDER 
         HOST TEST 
 - - - - - - - - - - -  - -     
                                  ht = HostTest(__host_test_name)
 |                        |       ht.setup()

 - - - - - - - - - - -  - - - - - -
          TEST CASE FLOW
 - - - - - - - - - - -  - - - - - -
 - - - - - - - - - - -  - -
 Since Host Test only responds to events. It is essential that target initiates
test by sending first event/key-value pair.
 - - - - - - - - - - -  - -     

 | {{start;value}}        |       |
 | -------------------->  |       |
 |          .             |       |  
 |          .             |       - - - - - - - - - -
 |          .             |        Host test responds to the 'start' event and sends back default target state.
 |          .             |       - - - - - - - - - - 
 | {{state;x}}            |       |  
 | <--------------------  |       |  
 |                        |       |  
 | {{echo;1}}             |       |
 | -------------------->  |       |
 | {{echo;1}}             |       |  
 | <--------------------  |       |  
 |          .             |       - - - - - - - - - -
 |          .             |        Target sends n echo events and expect n echoes back
 |          .             |       - - - - - - - - - - 
 | {{state;y}}            |       |
 | -------------------->  |       |
 | {{reset;0}}            |       |
 | -------------------->  |       |
 |          .             |       - - - - - - - - - -
 |          .             |        Target switches state and informs Host test. Then requests a reset
 |          .             |       - - - - - - - - - - 
 - - - - - - - - - - -  - -
 On event 'reset' host test sends event '__reset' that is internally handled by htrun event loop. 
It performs a software reset. On start-up target again performs sync handshake that is handled 
in the same way as before by htrun. Target then sends "start" event. On which host test sends its
current state.
 - - - - - - - - - - -  - -     
 | {{start;value}}        |       |
 | -------------------->  |       |
 |          .             |       |  
 |          .             |       - - - - - - - - - -
 |          .             |        Host test responds to the 'start' event and sends back current state.
 |          .             |       - - - - - - - - - - 
 | {{state;y}}            |       |  
 | <--------------------  |       |  
 |                        |       |  
 | {{echo;1}}             |       |
 | -------------------->  |       |
 | {{echo;2}}             |       |  
 | <--------------------  |       |  
 |          .             |       - - - - - - - - - -
 |          .             |        Target sends n echo events and expect n echoes back. But in state y target
 |          .             |        expects n x 2 in response echo.
 |          .             |       - - - - - - - - - - 
 - - - - - - - - - - -  - - - - - -
Target validated echoes and finishes the test.
 - - - - - - - - - - -  - - - - - -
 |                        |       |
 | {{end;success}}        |       |  
 | -------------------->  |       | 
 |                        |       |
 | {{__exit;%d}}          |       |  
 | -------------------->  |       | 
 - - - - - - - - - - -  - - - - - -
  DUT'S TEST SUITE ENDED
  CONSUME REMAINING EVENTS
 - - - - - - - - - - -  - - - - - -
 |                        |       |
 |                        |       | result = ht.result()
 |                        |       |<----------------
 |                        |       |
 |                        |       | ht.teardown()
 |                        |       |<----------------
 |                        |       |
 |                        |       |
```