### PR TITLE
Hardware reset feature

### DIFF
--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -40,7 +40,6 @@ class BaseHostTestAbstract(object):
     def __notify_dut(self, key, value):
         """! Send data over serial to DUT """
         if self.__event_queue:
-            print "adding to dut event queue %s %s" % (key, value)
             self.__dut_event_queue.put((key, value, time()))
 
     def notify_complete(self, result=None):

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -40,6 +40,7 @@ class BaseHostTestAbstract(object):
     def __notify_dut(self, key, value):
         """! Send data over serial to DUT """
         if self.__event_queue:
+            print "adding to dut event queue %s %s" % (key, value)
             self.__dut_event_queue.put((key, value, time()))
 
     def notify_complete(self, result=None):
@@ -49,13 +50,13 @@ class BaseHostTestAbstract(object):
         if self.__event_queue:
             self.__event_queue.put(('__notify_complete', result, time()))
 
-    def reset_dut(self):
+    def reset_dut(self, value):
         """
         Reset device under test
         :return:
         """
         if self.__event_queue:
-            self.__event_queue.put(('__reset_dut', True, time()))
+            self.__event_queue.put(('__reset_dut', value, time()))
 
     def notify_conn_lost(self, text):
         """! Notify main even loop that there was a DUT-host test connection error

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -93,8 +93,7 @@ class SerialConnectorPrimitive(object):
     def write_kv(self, key, value):
         kv_buff = "{{%s;%s}}\n"% (key, value)
         self.write(kv_buff)
-        print "Written: %s" % kv_buff
-        #self.logger.prn_txd(kv_buff)
+        self.logger.prn_txd(kv_buff)
         return kv_buff
 
     def flush(self):

--- a/mbed_host_tests/host_tests_plugins/__init__.py
+++ b/mbed_host_tests/host_tests_plugins/__init__.py
@@ -30,6 +30,7 @@ import host_test_registry
 import module_copy_shell
 import module_copy_mbed
 import module_reset_mbed
+import module_power_cycle_mbed
 
 # Additional, non standard platforms
 import module_copy_silabs
@@ -56,6 +57,7 @@ HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_silabs.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_silabs.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_stlink.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_stlink.load_plugin())
+HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_power_cycle_mbed.load_plugin())
 #HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_jn51xx.load_plugin())
 #HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_jn51xx.load_plugin())
 

--- a/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
@@ -62,8 +62,7 @@ class HostTestPluginPowerCycleResetMethod(HostTestPluginBase):
                 device_info = kwargs['device_info']
                 ret = self.__get_mbed_tas_rm_addr()
                 if ret:
-                    ip = ret[0]
-                    port = ret[1]
+                    ip, port = ret
                     result = self.__hw_reset(ip, port, target_id, device_info)
         return result
 

--- a/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
@@ -60,26 +60,28 @@ class HostTestPluginPowerCycleResetMethod(HostTestPluginBase):
             if capability in HostTestPluginPowerCycleResetMethod.capabilities:
                 target_id = kwargs['target_id']
                 device_info = kwargs['device_info']
-                result = self.__hw_reset(target_id, device_info)
+                ret = self.__get_mbed_tas_rm_addr()
+                if ret:
+                    ip = ret[0]
+                    port = ret[1]
+                    result = self.__hw_reset(ip, port, target_id, device_info)
         return result
 
-    def __hw_reset(self, target_id, device_info):
+    def __get_mbed_tas_rm_addr(self):
         """
-        Performs hardware reset of target mbed device.
-
+        Get IP and Port of mbed tas rm service.
         :return:
         """
-        result = False
         try:
             ip = os.environ['MBED_TAS_RM_IP']
             port = os.environ['MBED_TAS_RM_PORT']
+            return ip, port
         except KeyError, e:
-            self.print_plugin_error("HOST: Failed read environment variable (" + str(e) + "). Can't perform hardware reset.")
-        else:
-            result = self.__reset_target(ip, port, target_id, device_info)
-        return result
+            self.print_plugin_error("HOST: Failed to read environment variable (" + str(e) + "). Can't perform hardware reset.")
 
-    def __reset_target(self, ip, port, target_id, device_info):
+        return None
+
+    def __hw_reset(self, ip, port, target_id, device_info):
         """
         Reset target device using TAS RM API
 

--- a/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
@@ -65,7 +65,7 @@ class HostTestPluginPowerCycleResetMethod(HostTestPluginBase):
 
     def __hw_reset(self, target_id, device_info):
         """
-        Performs hardware reset of target ned device.
+        Performs hardware reset of target mbed device.
 
         :return:
         """

--- a/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_power_cycle_mbed.py
@@ -74,7 +74,7 @@ class HostTestPluginPowerCycleResetMethod(HostTestPluginBase):
             ip = os.environ['MBED_TAS_RM_IP']
             port = os.environ['MBED_TAS_RM_PORT']
         except KeyError, e:
-            print "HOST: Failed read environment variable (" + str(e) + "). Can't perform hardware reset."
+            self.print_plugin_error("HOST: Failed read environment variable (" + str(e) + "). Can't perform hardware reset.")
         else:
             result = self.__reset_target(ip, port, target_id, device_info)
         return result
@@ -118,11 +118,11 @@ class HostTestPluginPowerCycleResetMethod(HostTestPluginBase):
         # reset target
         switch_off_req = self.__run_request(ip, port, switch_off_req)
         if switch_off_req is None:
-            print "HOST: Failed to communicate with TAS RM!"
+            self.print_plugin_error("HOST: Failed to communicate with TAS RM!")
             return result
 
         if "error" in switch_off_req['sub_requests'][0]:
-            print "HOST: Failed to reset target. error = %s" % switch_off_req['sub_requests'][0]['error']
+            self.print_plugin_error("HOST: Failed to reset target. error = %s" % switch_off_req['sub_requests'][0]['error'])
             return result
 
         def poll_state(required_state):
@@ -153,7 +153,7 @@ class HostTestPluginPowerCycleResetMethod(HostTestPluginBase):
                 device_info[k] = v
             result = True
         else:
-            print "HOST: Failed to reset device %s" % target_id
+            self.print_plugin_error("HOST: Failed to reset device %s" % target_id)
 
         return result
 

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -196,18 +196,21 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             dut_event_queue.put(('__host_test_finished', True, time()))
                             p.join()
 
-                            assert value in \
-                                   [DefaultTestSelector.RESET_TYPE_SW_RST, DefaultTestSelector.RESET_TYPE_HW_RST], \
-                                "Unknown reset type (%s). Supported types 'software_reset' and 'hardware_reset'" % value
-
                             if value == DefaultTestSelector.RESET_TYPE_SW_RST:
-                                # Disconnecting and re-connecting comm process will reset DUT
-                                p = start_conn_process()
+                                self.logger.prn_inf("Performing software reset.")
+                                # Just disconnecting and re-connecting comm process will soft reset DUT
                             elif value == DefaultTestSelector.RESET_TYPE_HW_RST:
+                                self.logger.prn_inf("Performing hard reset.")
                                 # request hardware reset
                                 self.mbed.hw_reset()
-                                # connect to the device
-                                p = start_conn_process()
+                            else:
+                                self.logger.prn_err("Invalid reset type (%s). Supported types [%s]." %
+                                                    (value, ", ".join([DefaultTestSelector.RESET_TYPE_HW_RST,
+                                                                       DefaultTestSelector.RESET_TYPE_SW_RST])))
+                                self.logger.prn_inf("Software reset will be performed.")
+
+                            # connect to the device
+                            p = start_conn_process()
                         elif key == '__notify_conn_lost':
                             # This event is sent by conn_process, DUT connection was lost
                             self.logger.prn_err(value)

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -221,7 +221,6 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             callbacks__exit = True
                             break
                         elif key in callbacks:
-                            print 'received key value = %s %s ' % (key, value)
                             # Handle callback
                             callbacks[key](key, value, timestamp)
                         else:

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -36,6 +36,8 @@ from mbed_host_tests.host_tests_toolbox.host_functional import handle_send_break
 
 class DefaultTestSelector(DefaultTestSelectorBase):
     """! Select default host_test supervision (replaced after auto detection) """
+    RESET_TYPE_SW_RST   = "software_reset"
+    RESET_TYPE_HW_RST   = "hardware_reset"
 
     def __init__(self, options):
         """! ctor
@@ -190,11 +192,22 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             result = value
                             break
                         elif key == '__reset_dut':
-                            # Disconnecting and re-connecting comm process will reset DUT
+                            # Disconnect to avoid connection lost event
                             dut_event_queue.put(('__host_test_finished', True, time()))
                             p.join()
-                            # self.mbed.update_device_info() - This call is commented but left as it would be required in hard reset.
-                            p = start_conn_process()
+
+                            assert value in \
+                                   [DefaultTestSelector.RESET_TYPE_SW_RST, DefaultTestSelector.RESET_TYPE_HW_RST], \
+                                "Unknown reset type (%s). Supported types 'software_reset' and 'hardware_reset'" % value
+
+                            if value == DefaultTestSelector.RESET_TYPE_SW_RST:
+                                # Disconnecting and re-connecting comm process will reset DUT
+                                p = start_conn_process()
+                            elif value == DefaultTestSelector.RESET_TYPE_HW_RST:
+                                # request hardware reset
+                                self.mbed.hw_reset()
+                                # connect to the device
+                                p = start_conn_process()
                         elif key == '__notify_conn_lost':
                             # This event is sent by conn_process, DUT connection was lost
                             self.logger.prn_err(value)
@@ -208,6 +221,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             callbacks__exit = True
                             break
                         elif key in callbacks:
+                            print 'received key value = %s %s ' % (key, value)
                             # Handle callback
                             callbacks[key](key, value, timestamp)
                         else:

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -188,15 +188,20 @@ class Mbed:
             switch_state_req = self.run_request(ip, port, switch_state_req)
 
         start = time.time()
-        switch_on_req = self.run_request(ip, port, switch_on_req)
-        while (switch_on_req['sub_requests'][0]['state'] != 'ON' or
-                       switch_on_req['sub_requests'][0]["mount_point"] == "Not Connected") and \
+        self.run_request(ip, port, switch_on_req)
+        switch_state_req = self.run_request(ip, port, switch_state_req)
+        while (switch_state_req['sub_requests'][0]['state'] != 'ON' or
+                       switch_state_req['sub_requests'][0]["mount_point"] == "Not Connected") and \
                         (time.time() - start) < 300:
             time.sleep(2)
-            switch_on_req = self.run_request(ip, port, switch_on_req)
+            switch_state_req = self.run_request(ip, port, switch_state_req)
 
-        self.port = switch_on_req['sub_requests'][0]['serial_port']
-        self.disk = switch_on_req['sub_requests'][0]['mount_point']
+        if (switch_state_req['sub_requests'][0]['state'] == 'ON' and
+                       switch_state_req['sub_requests'][0]["mount_point"] != "Not Connected"):
+            self.port = switch_state_req['sub_requests'][0]['serial_port']
+            self.disk = switch_state_req['sub_requests'][0]['mount_point']
+	else:
+	    print "HOST: Failed to reset device %s" % self.target_id
 
     def run_request(self, ip, port, request):
         """

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -188,10 +188,8 @@ class Mbed:
             }
             resp = self.run_request(ip, port, switch_state_req)
             start = time.time()
-            while resp and resp['sub_requests'][0]['state'] != required_state and \
-                    (required_state == 'OFF' or (required_state == 'ON' and
-                                                         resp['sub_requests'][0]["mount_point"] != "Not Connected")) and \
-                            (time.time() - start) < 300:
+            while resp and (resp['sub_requests'][0]['state'] != required_state or (required_state == 'ON' and
+                            resp['sub_requests'][0]["mount_point"] == "Not Connected")) and (time.time() - start) < 300:
                 time.sleep(2)
                 resp = self.run_request(ip, port, resp)
             return resp
@@ -221,3 +219,4 @@ class Mbed:
             return resp
         else:
             return None
+

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -17,10 +17,7 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
-import os
 import json
-import time
-import requests
 from time import sleep
 import mbed_host_tests.host_tests_plugins as ht_plugins
 

--- a/setup.py
+++ b/setup.py
@@ -53,4 +53,5 @@ setup(name='mbed-host-tests',
              "mbedflsh=mbed_host_tests.mbedflsh:main"],
       },
       install_requires=["PySerial>=3.0",
-        "PrettyTable>=0.7.2"])
+                        "PrettyTable>=0.7.2",
+                        "requests"])


### PR DESCRIPTION
Extension on PR https://github.com/ARMmbed/htrun/pull/75 for hardware reset. Please see feature documentation in https://github.com/ARMmbed/htrun/pull/75

Changes:

Now ```reset_dut(reset_type)``` accepts an argument ```reset_type``` that can have two string value ```software_reset``` or ```hardware_reset```. 
* ```software_reset``` resets the device by sending break command over serial.
* ```hardware_reset``` uses mbed-tas-rm service to reset the device.

Target test can initiate software or hardware reset by sending ```software_reset``` or ```hardware_reset``` as value with a corresponding event key. Target can either send a host test handled key for which host test calls ```reset_dut```. Or target can directly send ```{{__reset_dut;<reset type>}}``` and htrun event loop will reset the target.

For hardware reset htrun requires that environment variables ```MBED_TAS_RM_IP``` and ```MBED_TAS_RM_PORT``` are set. In Jenkins these environment variables are set in Jenkins->Configure->Global environment settings. On desktop user would need to set these environment variables pointing to locally running mbed-tas-rm service. See https://github.com/ARMmbed/mbed-tas-rm documentation.
