### PR TITLE
Add warning regarding missing BaseHostTest ctor call in custom host test

### DIFF
--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -229,5 +229,17 @@ class HostTestCallbackBase(BaseHostTestAbstract):
 
 class BaseHostTest(HostTestCallbackBase):
 
+    __BaseHostTest_Called = False
+
+    def base_host_test_inited(self):
+        """ This function will check if BaseHostTest ctor was called
+            Call to BaseHostTest is required in order to force required
+            interfaces implementation.
+            @return Returns True if ctor was called (ok behaviour)
+        """
+        return self.__BaseHostTest_Called
+
     def __init__(self):
         HostTestCallbackBase.__init__(self)
+        self.__BaseHostTest_Called = True
+

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -83,12 +83,15 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         @return True if obj_instance is derived from mbed_host_tests.BaseHostTest()
                 and BaseHostTest.__init__() was called, else return False
         """
-        result = True
+        result = False
         if obj_instance:
-            # Check if host test (obj_instance) is derived from mbed_host_tests.BaseHostTest()
+            result = True
             self.logger.prn_inf("host test class: '%s'"% obj_instance.__class__)
 
+            # Check if host test (obj_instance) is derived from mbed_host_tests.BaseHostTest()
             if not isinstance(obj_instance, BaseHostTest):
+                # In theory we should always get host test objects inheriting from BaseHostTest()
+                # because loader will only load those.
                 self.logger.prn_err("host test must inherit from mbed_host_tests.BaseHostTest() class")
                 result = False
 

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -142,6 +142,14 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             # Load dynamically requested host test
                             self.test_supervisor = get_host_test(value)
                             if self.test_supervisor:
+                                if not self.test_supervisor.base_host_test_inited():
+                                    self.logger.prn_err("==== host test script '%s' error ===="% value)
+                                    self.logger.prn_err("* host test doesn't inherit from mbed_host_tests.BaseHostTest() class or")
+                                    self.logger.prn_err("* BaseHostTest.__init__(self) not called in host test script constructor")
+                                    self.logger.prn_err("==== host test script error ====")
+                                    result = self.RESULT_ERROR
+                                    break
+
                                 # Pass communication queues and setup() host test
                                 self.test_supervisor.setup_communication(event_queue, dut_event_queue)
                                 try:

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -23,6 +23,7 @@ import traceback
 from time import time
 from Queue import Empty as QueueEmpty   # Queue here refers to the module, not a class
 
+from mbed_host_tests import BaseHostTest
 from multiprocessing import Process, Queue, Lock
 from mbed_host_tests import print_ht_list
 from mbed_host_tests import get_host_test
@@ -32,7 +33,6 @@ from mbed_host_tests.host_tests_conn_proxy import HtrunLogger
 from mbed_host_tests.host_tests_conn_proxy import conn_process
 from mbed_host_tests.host_tests_runner.host_test import DefaultTestSelectorBase
 from mbed_host_tests.host_tests_toolbox.host_functional import handle_send_break_cmd
-
 
 class DefaultTestSelector(DefaultTestSelectorBase):
     """! Select default host_test supervision (replaced after auto detection) """
@@ -74,7 +74,37 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         DefaultTestSelectorBase.__init__(self, options)
 
+    def is_host_test_obj_compatible(self, obj_instance):
+        """! Check if host test object loaded is actually host test class
+             derived from 'mbed_host_tests.BaseHostTest()'
+             Additionaly if host test class implements custom ctor it should
+             call BaseHostTest().__Init__()
+        @param obj_instance Instance of host test derived class
+        @return True if obj_instance is derived from mbed_host_tests.BaseHostTest()
+                and BaseHostTest.__init__() was called, else return False
+        """
+        if obj_instance:
+            # Check if host test (obj_instance) is derived from mbed_host_tests.BaseHostTest()
+            if not isinstance(obj_instance, BaseHostTest):
+                self.logger.prn_err("host test must inherit from mbed_host_tests.BaseHostTest() class")
+                self.logger.prn_err("host test class '%s'"% obj_instance.__class__)
+                return False
+
+            # Check if BaseHostTest.__init__() was called when custom host test is created
+            if not self.obj_instance.base_host_test_inited():
+                self.logger.prn_err("custom host test __init__() must call BaseHostTest.__init__(self)")
+                self.logger.prn_err("host test class '%s'"% obj_instance.__class__)
+                return False
+
+            # It is a valid host test class object
+            return True
+        return False
+
     def run_test(self):
+        """! This function implements key-value protocol state-machine.
+            Handling of all events and connector are handled here.
+        @return Return self.TestResults.RESULT_* enum
+        """
         result = None
         timeout_duration = 10       # Default test case timeout
         event_queue = Queue()       # Events from DUT to host
@@ -141,15 +171,12 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                         elif key == '__host_test_name':
                             # Load dynamically requested host test
                             self.test_supervisor = get_host_test(value)
-                            if self.test_supervisor:
-                                if not self.test_supervisor.base_host_test_inited():
-                                    self.logger.prn_err("==== host test script '%s' error ===="% value)
-                                    self.logger.prn_err("* host test doesn't inherit from mbed_host_tests.BaseHostTest() class or")
-                                    self.logger.prn_err("* BaseHostTest.__init__(self) not called in host test script constructor")
-                                    self.logger.prn_err("==== host test script error ====")
-                                    result = self.RESULT_ERROR
-                                    break
 
+                            # Check if host test object loaded is actually host test class
+                            # derived from 'mbed_host_tests.BaseHostTest()'
+                            # Additionaly if host test class implements custom ctor it should
+                            # call BaseHostTest().__Init__()
+                            if self.is_host_test_obj_compatible(self.test_supervisor):
                                 # Pass communication queues and setup() host test
                                 self.test_supervisor.setup_communication(event_queue, dut_event_queue)
                                 try:
@@ -174,6 +201,9 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                                 self.logger.prn_inf("host test detected: %s"% value)
                             else:
                                 self.logger.prn_err("host test not detected: %s"% value)
+                                result = self.RESULT_ERROR
+                                break
+
                             consume_preamble_events = False
                         elif key == '__sync':
                             # This is DUT-Host Test handshake event

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -83,22 +83,21 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         @return True if obj_instance is derived from mbed_host_tests.BaseHostTest()
                 and BaseHostTest.__init__() was called, else return False
         """
+        result = True
         if obj_instance:
             # Check if host test (obj_instance) is derived from mbed_host_tests.BaseHostTest()
+            self.logger.prn_inf("host test class: '%s'"% obj_instance.__class__)
+
             if not isinstance(obj_instance, BaseHostTest):
                 self.logger.prn_err("host test must inherit from mbed_host_tests.BaseHostTest() class")
-                self.logger.prn_err("host test class '%s'"% obj_instance.__class__)
-                return False
+                result = False
 
             # Check if BaseHostTest.__init__() was called when custom host test is created
-            if not self.obj_instance.base_host_test_inited():
+            if not obj_instance.base_host_test_inited():
                 self.logger.prn_err("custom host test __init__() must call BaseHostTest.__init__(self)")
-                self.logger.prn_err("host test class '%s'"% obj_instance.__class__)
-                return False
+                result = False
 
-            # It is a valid host test class object
-            return True
-        return False
+        return result
 
     def run_test(self):
         """! This function implements key-value protocol state-machine.
@@ -176,7 +175,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             # derived from 'mbed_host_tests.BaseHostTest()'
                             # Additionaly if host test class implements custom ctor it should
                             # call BaseHostTest().__Init__()
-                            if self.is_host_test_obj_compatible(self.test_supervisor):
+                            if self.test_supervisor and self.is_host_test_obj_compatible(self.test_supervisor):
                                 # Pass communication queues and setup() host test
                                 self.test_supervisor.setup_communication(event_queue, dut_event_queue)
                                 try:


### PR DESCRIPTION
This PR is response for https://github.com/ARMmbed/htrun/issues/80.

Changes:
* Add check if custom host test (in most cases loaded from ```<module>/test/host_tests```) inherits from ```mbed_host_tests.BaseHostTest()``` and calls required ```BaseHostTest.__init__(self)``` ctor.

This change applies to all developers writing host tests where they create custom ctor for their host test.
Example:
```python
from mbed_host_tests import BaseHostTest

class MyCustomHostTest(BaseHostTest):

    # Custom host test script constructor!
    # We have to call BaseHostTest.__init__(self)
    def __init__(self):
        BaseHostTest.__init__(self)    # OK
        pass

    # host test implementation
```
or
```python
from mbed_host_tests import BaseHostTest

class MyCustomHostTest(BaseHostTest):
    # No __init__(self)
    # BaseHostTest.__init__(self) will be called automatically

    # host test implementation
```

In case users have custom host test with ```__init__(self) defined and no call to ```BaseHostTest.__init__(self)``` ```htrun``` will yield error and message as seen below:
```
[1460987409.99][HTST][ERR] ==== host test script 'test_auto' error ====
[1460987409.99][HTST][ERR] * host test doesn't inherit from mbed_host_tests.BaseHostTest() class or
[1460987409.99][HTST][ERR] * BaseHostTest.__init__(self) not called in host test script constructor
[1460987409.99][HTST][ERR] ==== host test script error ====
```
Please note that ```htrun``` will also return ```ERROR``` for given test suite.
Example:
```
...
[1460987409.99][HTST][ERR] ==== host test script 'test_auto' error ====
[1460987409.99][HTST][ERR] * host test doesn't inherit from mbed_host_tests.BaseHostTest() class or
[1460987409.99][HTST][ERR] * BaseHostTest.__init__(self) not called in host test script constructor
[1460987409.99][HTST][ERR] ==== host test script error ====
[1460987409.99][HTST][INF] test suite run finished after 0.04 sec...
[1460987410.00][HTST][INF] CONN exited with code: 0
[1460987410.00][HTST][INF] Some events in queue
[1460987410.00][HTST][INF] stopped consuming events
[1460987410.00][HTST][INF] host test result() call skipped, received: error
[1460987410.00][HTST][WRN] missing __exit event from DUT
[1460987410.00][HTST][INF] calling blocking teardown()
[1460987410.00][HTST][INF] teardown() finished
[1460987410.00][HTST][INF] {{result;error}}
mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'ERROR'
mbedgt: test case summary event not found
        no test case report present, assuming test suite to be a single test case!
        test suite: mbed-drivers-test-generic_tests
        test case: generic_tests
mbedgt: test on hardware with target id: 0240000033514e45002c500585d4001ee981000097969900
mbedgt: test suite 'mbed-drivers-test-generic_tests' ................................................. ERROR in 10.64 sec
        test case: 'generic_tests' ................................................................... ERROR in 10.64 sec
...

```
