### PR TITLE
[ready to merge] Add to --list switch a -e ./test/host_tests

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -96,7 +96,7 @@ def get_plugin_caps(methods=None):
         result[method] = host_tests_plugins.get_plugin_caps(method)
     return result
 
-def print_ht_list():
+def print_ht_list(verbose=False):
     """! Prints list of registered host test classes (by name)
         @Detail For devel & debug purposes
     """
@@ -104,13 +104,23 @@ def print_ht_list():
     # Opiortunistic apporach
     # If in yotta module top level dir try to list all
     # tests in standard test/host_tests path
-    enum_host_tests('./test/host_tests')
+    enum_host_tests('./test/host_tests', verbose=verbose)
 
-    str_len = 0
+    ht_str_len = 0
+    cls_str_len = 0
     for ht in HOSTREGISTRY.HOST_TESTS:
-        if len(ht) > str_len: str_len = len(ht)
+        cls_str = str(HOSTREGISTRY.HOST_TESTS[ht].__class__)
+
+        if len(ht) > ht_str_len: ht_str_len = len(ht)
+        if len(cls_str) > cls_str_len: cls_str_len = len(cls_str)
     for ht in sorted(HOSTREGISTRY.HOST_TESTS.keys()):
-        print "'%s'%s : %s()" % (ht, ' '*(str_len - len(ht)), HOSTREGISTRY.HOST_TESTS[ht].__class__)
+        cls_str = str(HOSTREGISTRY.HOST_TESTS[ht].__class__)
+        script_path_str = HOSTREGISTRY.HOST_TESTS[ht].script_location if HOSTREGISTRY.HOST_TESTS[ht].script_location else 'mbed-host-tests'
+
+        print "'%s'%s : %s()%s @ '%s'" % (ht, ' '*(ht_str_len - len(ht)),
+            cls_str,
+            ' '*(cls_str_len - len(cls_str)),
+            script_path_str)
 
 def enum_host_tests(path, verbose=False):
     """ Enumerates and registers locally stored host tests
@@ -146,6 +156,7 @@ def enum_host_tests(path, verbose=False):
                                 if mod_obj.name:
                                     host_test_name = mod_obj.name
                                 host_test_cls = mod_obj
+                                host_test_cls.script_location = abs_path
                                 if verbose:
                                     print "HOST: Found host test implementation: %s -|> %s"% (str(mod_obj), str(BaseHostTest))
                                     print "HOST: Registering '%s' as '%s'"% (str(host_test_cls), host_test_name)

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -100,12 +100,17 @@ def print_ht_list():
     """! Prints list of registered host test classes (by name)
         @Detail For devel & debug purposes
     """
+
+    # Opiortunistic apporach
+    # If in yotta module top level dir try to list all
+    # tests in standard test/host_tests path
+    enum_host_tests('./test/host_tests')
+
     str_len = 0
     for ht in HOSTREGISTRY.HOST_TESTS:
         if len(ht) > str_len: str_len = len(ht)
     for ht in sorted(HOSTREGISTRY.HOST_TESTS.keys()):
         print "'%s'%s : %s()" % (ht, ' '*(str_len - len(ht)), HOSTREGISTRY.HOST_TESTS[ht].__class__)
-
 
 def enum_host_tests(path, verbose=False):
     """ Enumerates and registers locally stored host tests

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -25,9 +25,10 @@ class BaseHostTestAbstract(object):
         setup, test and teardown set of functions
     """
 
-    name = ''   # name of the host test (used for local registration)
-    __event_queue = None      # To main even loop
-    __dut_event_queue = None  # To DUT
+    name = ''                   # name of the host test (used for local registration)
+    __event_queue = None        # To main even loop
+    __dut_event_queue = None    # To DUT
+    script_location = None      # Path to source file used to load host test
 
     def __notify_prn(self, text):
         if self.__event_queue:

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -52,7 +52,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 enum_host_tests(path, verbose=options.verbose)
 
             if options.list_reg_hts:    # --list option
-                print_ht_list()
+                print_ht_list(verbose=options.verbose)
                 sys.exit(0)
 
             if options.list_plugins:    # --plugins option


### PR DESCRIPTION
This change will show all loadable from current directory host tests.

# Description

Normally users use ```--list``` switch to show all loadable host tests:
```
$ cd <module>
```
```
$ mbedhtrun --list
```
```
'default'       : <class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>()
'default_auto'  : <class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>()
'detect_auto'   : <class 'mbed_host_tests.host_tests.detect_auto.DetectPlatformTest'>()
'dev_null_auto' : <class 'mbed_host_tests.host_tests.dev_null_auto.DevNullTest'>()
'echo'          : <class 'mbed_host_tests.host_tests.echo.EchoTest'>()
'hello_auto'    : <class 'mbed_host_tests.host_tests.hello_auto.HelloTest'>()
'rtc_auto'      : <class 'mbed_host_tests.host_tests.rtc_auto.RTCTest'>()
'wait_us_auto'  : <class 'mbed_host_tests.host_tests.wait_us_auto.WaitusTest'>()
```

If users have additional host tests in ```<module>/test/host_tests``` they had to issue additional ```-e ./test/host_tests``` switch with ```--list```.
```
$ mbedhtrun --list -e ./test/host_tests
```
Note that ```<module>/test/host_tests``` is default and assumed by test tools path with custom host tests in yotta module. For example Greentea will always add default ```-e ./test/host_tests``` switch to ```htrun``` call.

## Change
* With this change ```$ mbedhtrun --list``` and ```$ mbedhtrun --list -e ./test/host_tests``` have the same behavior.
* User can still specify ```-e``` switch to load host tests from additional source!. For example:
```
$ mbedhtrun --list -e mbed-drivers/test/host_tests/
```
