### PR TITLE
Add mount point checks with mbed_lstools before flashing

### DIFF
--- a/mbed_host_tests/host_tests_plugins/host_test_plugins.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_plugins.py
@@ -124,6 +124,7 @@ class HostTestPluginBase:
 
             # Sometimes OSes take a long time to mount devices (up to one minute).
             # Current pooling time: 120x 500ms = 1 minute
+            self.print_plugin_info("Waiting for '%s' mount point (current is '%s')..."% (target_id, destination_disk))
             for i in range(120):
                 # mbed_lstools.create() should be done inside the loop.
                 # Otherwise it will loop on same data.
@@ -133,12 +134,11 @@ class HostTestPluginBase:
                     if 'mount_point' in mbeds_by_tid[target_id]:
                         new_destination_disk = mbeds_by_tid[target_id]['mount_point']
                         break
-                self.print_plugin_info("Waiting for '%s' mount point (current is '%s')..."% (target_id, destination_disk))
                 sleep(0.5)
 
             if new_destination_disk != destination_disk:
                 # Mount point changed, update to new mount point from mbed-ls
-                self.print_plugin_info("Mount point for tid='%s' changed from '%s' to '%s'..."% (target_id, destination_disk, new_destination_disk))
+                self.print_plugin_info("Mount point for '%s' changed from '%s' to '%s'..."% (target_id, destination_disk, new_destination_disk))
                 destination_disk = new_destination_disk
 
         result = False

--- a/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
@@ -73,7 +73,7 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
             return False
 
         # This optional parameter can be used if TargetID is provided (-t switch)
-        target_id = kwargs['target_id']
+        target_id = kwargs.get('target_id', None)
 
         result = False
         if self.check_parameters(capability, *args, **kwargs):

--- a/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
@@ -72,6 +72,9 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
             self.print_plugin_error("Error: destination disk not specified")
             return False
 
+        # This optional parameter can be used if TargetID is provided (-t switch)
+        target_id = kwargs['target_id']
+
         result = False
         if self.check_parameters(capability, *args, **kwargs):
             # Capability 'default' is a dummy capability
@@ -80,7 +83,9 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
                     image_path = os.path.normpath(kwargs['image_path'])
                     destination_disk = os.path.normpath(kwargs['destination_disk'])
                     # Wait for mount point to be ready
-                    self.check_mount_point_ready(destination_disk)  # Blocking
+                    # if mount point changed according to target_id use new mount point
+                    # available in result (_, destination_disk) of check_mount_point_ready
+                    mount_res, destination_disk = self.check_mount_point_ready(destination_disk, target_id=self.target_id)  # Blocking
                     result = self.generic_mbed_copy(image_path, destination_disk)
         return result
 

--- a/mbed_host_tests/host_tests_plugins/module_copy_shell.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_shell.py
@@ -53,13 +53,18 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
             self.print_plugin_error("Error: destination disk not specified")
             return False
 
+        # This optional parameter can be used if TargetID is provided (-t switch)
+        target_id = kwargs['target_id']
+
         result = False
         if self.check_parameters(capability, *args, **kwargs):
             if kwargs['image_path'] and kwargs['destination_disk']:
                 image_path = os.path.normpath(kwargs['image_path'])
                 destination_disk = os.path.normpath(kwargs['destination_disk'])
                 # Wait for mount point to be ready
-                self.check_mount_point_ready(destination_disk)  # Blocking
+                # if mount point changed according to target_id use new mount point
+                # available in result (_, destination_disk) of check_mount_point_ready
+                mount_res, destination_disk = self.check_mount_point_ready(destination_disk, target_id=target_id)  # Blocking
                 # Prepare correct command line parameter values
                 image_base_name = basename(image_path)
                 destination_path = join(destination_disk, image_base_name)

--- a/mbed_host_tests/host_tests_plugins/module_copy_shell.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_shell.py
@@ -54,7 +54,7 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
             return False
 
         # This optional parameter can be used if TargetID is provided (-t switch)
-        target_id = kwargs['target_id']
+        target_id = kwargs.get('target_id', None)
 
         result = False
         if self.check_parameters(capability, *args, **kwargs):

--- a/mbed_host_tests/host_tests_runner/host_test.py
+++ b/mbed_host_tests/host_tests_runner/host_test.py
@@ -17,6 +17,7 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
+import pkg_resources  # part of setuptools
 from sys import stdout
 from mbed_host_tests.host_tests_runner.mbed_base import Mbed
 
@@ -120,6 +121,13 @@ class Test(HostTestResults):
         """ dctor for this class, finishes tasks and closes resources
         """
         pass
+
+    def get_hello_string(self):
+        """ Hello string used as first print
+        """
+        pkg = 'mbed-host-tests'
+        version = pkg_resources.require(pkg)[0].version
+        return "host test executor ver. " + version
 
 
 class DefaultTestSelectorBase(Test):

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -294,6 +294,9 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         """
         result = self.RESULT_UNDEF
 
+        # hello sting with htrun version, for debug purposes
+        self.logger.prn_inf(self.get_hello_string())
+
         try:
             # Copy image to device
             if self.options.skip_flashing:

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -113,7 +113,8 @@ class Mbed:
                                         copy_method,
                                         image_path=image_path,
                                         serial=port,
-                                        destination_disk=disk)
+                                        destination_disk=disk,
+                                        target_id=self.target_id)
         return result
 
     def update_device_info(self):

--- a/setup.py
+++ b/setup.py
@@ -53,4 +53,5 @@ setup(name='mbed-host-tests',
              "mbedflsh=mbed_host_tests.mbedflsh:main"],
       },
       install_requires=["PySerial>=3.0",
-        "PrettyTable>=0.7.2"])
+                        "PrettyTable>=0.7.2",
+                        "mbed-ls"])


### PR DESCRIPTION
## Description
We are not protecting test run from device mount point change when calling `mbedhtrun`.

## Changes:
* Add to `shell` and `shutil` plugins mount guards checking if mount point changed and/or is valid.
  * If mount point changed warning will be issues and new mount point will be used for copy/flash procedure. 
* Add `htrun` version print (first print by `htrun`) for debugging purposes:
```
[1462545824.12][HTST][INF] host test executor ver. 0.2.6
```

@mazimkhan @adbridge @bridadan Please review. 
This will be delivered separately to features:
* Serial port check before reset and
* HW reset recovery feature I think.

## Example usage
I've called `mbedhtrun` with correct `target_id` and wrong mount point `X:` and got correct response from `HostTestPluginCopyMethod_Shell` plugin with correct mount point value of mount point from `mbed_lstools`.

```
$ mbedhtrun -d X: -p COM218:9600 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-generic_tests.bin" -C 4 -c shell -m K64F -t 0240000033514e450043500585d4003fe981000097969900
```
```
[1462545824.12][HTST][INF] host test executor ver. 0.2.6
[1462545824.12][HTST][INF] copy image onto target...
Plugin info: HostTestPluginCopyMethod_Shell::CopyMethod: Mount point for tid='0240000033514e450043500585d4003fe981000097969900' changed from 'X:' to 'E:'...
        1 file(s) copied.
[1462545832.54][HTST][INF] starting host test process...
```