### PR TITLE
Add serial port checks with mbed_lstools before opening port by listener

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -27,10 +27,8 @@ Write your own programs (import this package) or use 'mbedhtrun' command line to
 
 
 import os
-import sys
 import imp
 import inspect
-from time import time
 from os import listdir
 from os.path import isfile, join, abspath
 from optparse import OptionParser

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -22,6 +22,7 @@ from time import time, sleep
 from Queue import Empty as QueueEmpty   # Queue here refers to the module, not a class
 from serial import Serial, SerialException
 from mbed_host_tests import host_tests_plugins
+from mbed_host_tests.host_tests_plugins.host_test_plugins import HostTestPluginBase
 from conn_proxy_logger import HtrunLogger
 
 
@@ -34,10 +35,25 @@ class SerialConnectorPrimitive(object):
         self.config = config
         self.logger = HtrunLogger(prn_lock, 'SERI')
         self.LAST_ERROR = None
+        self.target_id = self.config.get('target_id', None)
 
+        # Values used to call serial port listener...
         self.logger.prn_inf("serial(port=%s, baudrate=%d)"% (self.port, self.baudrate))
+
+        # Check if serial port for given target_id changed
+        # If it does we will use new port to open connections and make sure reset plugin
+        # later can reuse opened already serial port
+        #
+        # Note: This listener opens serial port and keeps connection so reset plugin uses
+        # serial port object not serial port name!
+        _, serial_port = HostTestPluginBase().check_serial_port_ready(self.port, target_id=self.target_id)
+        if serial_port != self.port:
+            # Serial port changed for given targetID
+            self.logger.prn_inf("serial port changed from '%s to '%s')"% (self.port, serial_port))
+            self.port = serial_port
+
         try:
-            self.serial = Serial(port, baudrate=baudrate, timeout=self.timeout)
+            self.serial = Serial(self.port, baudrate=self.baudrate, timeout=self.timeout)
         except SerialException as e:
             self.serial = None
             self.LAST_ERROR = "connection lost, serial.Serial(%s. %d, %d): %s"% (self.port,
@@ -59,7 +75,8 @@ class SerialConnectorPrimitive(object):
         result = host_tests_plugins.call_plugin('ResetMethod',
             reset_type,
             serial=self.serial,
-            disk=disk)
+            disk=disk,
+            target_id=self.target_id)
         # Post-reset sleep
         self.logger.prn_inf("wait for it...")
         sleep(delay)
@@ -67,7 +84,7 @@ class SerialConnectorPrimitive(object):
 
     def read(self, count):
         """! Read data from serial port RX buffer """
-        c = ''
+        c = str()
         try:
             if self.serial:
                 c = self.serial.read(count)
@@ -115,7 +132,7 @@ class KiViBufferWalker():
     """! Simple auxiliary class used to walk through a buffer and search for KV tokens """
     def __init__(self):
         self.KIVI_REGEX = r"\{\{([\w\d_-]+);([^\}]+)\}\}"
-        self.buff = ''
+        self.buff = str()
         self.buff_idx = 0
         self.re_kv = re.compile(self.KIVI_REGEX)
 
@@ -157,7 +174,7 @@ def conn_process(event_queue, dut_event_queue, prn_lock, config):
     sync_uuid_discovered = False
 
     # Some RXD data buffering so we can show more text per log line
-    print_data = ''
+    print_data = str()
 
     # Handshake, we will send {{sync;UUID}} preamble and wait for mirrored reply
     logger.prn_inf("sending preamble '%s'..."% sync_uuid)
@@ -197,7 +214,7 @@ def conn_process(event_queue, dut_event_queue, prn_lock, config):
                         if line:
                             logger.prn_rxd(line)
                             event_queue.put(('__rxd_line', line, time()))
-                    print_data = ''
+                    print_data = str()
                 else:
                     for line in print_data_lines[:-1]:
                         if line:

--- a/mbed_host_tests/host_tests_plugins/host_test_plugins.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_plugins.py
@@ -134,22 +134,22 @@ class HostTestPluginBase:
         result = True
 
         if target_id:
-            mbeds = mbed_lstools.create()
-            mbeds_by_tid = mbeds.list_mbeds_by_targetid()   # key: target_id, value mbedls_dict()
-
             # Wait for mount point to appear with mbed-ls
             # and if it does check if mount point for target_id changed
             # If mount point changed, use new mount point and check if its ready (os.access)
             new_serial_port = serial_port
             for i in range(25): # 25x 200ms = 5sec
+                # mbed_lstools.create() should be done inside the loop. Otherwise it will loop on same data.
+                mbeds = mbed_lstools.create()
+                mbeds_by_tid = mbeds.list_mbeds_by_targetid()   # key: target_id, value mbedls_dict()
                 if target_id in mbeds_by_tid:
                     if 'serial_port' in mbeds_by_tid[target_id]:
                         new_serial_port = mbeds_by_tid[target_id]['serial_port']
                         break
-                sleep(200)
+                sleep(0.2)
 
             if new_serial_port != serial_port:
-                # Mount point changed, update to new mount point from mbed-ls
+                # Serial port changed, update to new serial port from mbed-ls
                 self.print_plugin_info("Serial port for tid='%s' changed from '%s' to '%s'..."% (target_id, serial_port, new_serial_port))
                 serial_port = new_serial_port
 

--- a/mbed_host_tests/host_tests_plugins/host_test_plugins.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_plugins.py
@@ -131,6 +131,12 @@ class HostTestPluginBase:
         return result
 
     def check_serial_port_ready(self, serial_port, target_id=None):
+        """! Function checks (using mbed-ls) and updates serial port name information for DUT with specified target_id.
+        If no target_id is specified function returns old serial port name.
+        @param serial_port Current serial port name
+        @param target_id Target ID of a device under test which serial port will be checked and updated if needed
+        @return Tuple with result (always True) and serial port read from mbed-ls
+        """
         result = True
 
         if target_id:
@@ -157,12 +163,10 @@ class HostTestPluginBase:
 
     def check_parameters(self, capability, *args, **kwargs):
         """! This function should be ran each time we call execute() to check if none of the required parameters is missing
-
-        @return Returns True if all parameters are passed to plugin, else return False
-
         @param capability Capability name
         @param args Additional parameters
         @param kwargs Additional parameters
+        @return Returns True if all parameters are passed to plugin, else return False
         """
         missing_parameters = []
         for parameter in self.required_parameters:
@@ -175,12 +179,9 @@ class HostTestPluginBase:
 
     def run_command(self, cmd, shell=True):
         """! Runs command from command line.
-
         @param cmd Command to execute
         @param shell True if shell command should be executed (eg. ls, ps)
-
         @details Function prints 'cmd' return code if execution failed
-
         @return True if command successfully executed
         """
         result = True
@@ -197,7 +198,6 @@ class HostTestPluginBase:
 
     def mbed_os_info(self):
         """! Returns information about host OS
-
         @return Returns tuple with information about OS and host platform
         """
         result = (os.name,

--- a/mbed_host_tests/host_tests_plugins/host_test_plugins.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_plugins.py
@@ -140,9 +140,7 @@ class HostTestPluginBase:
         result = True
 
         if target_id:
-            # Wait for mount point to appear with mbed-ls
-            # and if it does check if mount point for target_id changed
-            # If mount point changed, use new mount point and check if its ready (os.access)
+            # If serial port changed (check using mbed-ls), use new serial port
             new_serial_port = serial_port
             for i in range(25): # 25x 200ms = 5sec
                 # mbed_lstools.create() should be done inside the loop. Otherwise it will loop on same data.

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -107,7 +107,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "port" : self.mbed.port,
                 "baudrate" : self.mbed.serial_baud,
                 "program_cycle_s" : self.options.program_cycle_s,
-                "reset_type" : self.options.forced_reset_type
+                "reset_type" : self.options.forced_reset_type,
+                "target_id" : self.options.target_id
             }
             # DUT-host communication process
             args = (event_queue, dut_event_queue, self.prn_lock, config)

--- a/mbed_host_tests/host_tests_toolbox/host_functional.py
+++ b/mbed_host_tests/host_tests_toolbox/host_functional.py
@@ -17,6 +17,8 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 """
 
+import sys
+import json
 from time import sleep
 from serial import Serial, SerialException
 from mbed_host_tests import host_tests_plugins


### PR DESCRIPTION
## Description
We are not protecting test run from device serial port change when calling `mbedhtrun`.

## Changes:
* Add to `mbed_reset` plugins guards checking if serial port changed and/or is valid.
  * If serial port changed warning will be issues and new serial port will be used for reset/sendBreak procedure.

@mazimkhan @adbridge @bridadan Please review. 
This will be delivered separately to features:
* Mount point check before reset and
* HW reset recovery feature I think.

## Example usage
I've called `mbedhtrun` with correct `target_id` and wrong serial port `COMx:` and got correct response from `HostTestPluginBase::BasePlugin` plugin with correct serial port name from `mbed_lstools`.

Note: Connection listener will open serial port and keep it open while later reset plugin will reuse OBJECT not PORT name so we only check port name before we open and keep serial port.

```
$ mbedhtrun -d E: -p COMx:9600 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-generic_tests.bin" -C 4 -c shell -m K64F -t 0240000033514e450043500585d4003fe981000097969900
```
```
[1462549672.72][HTST][INF] copy image onto target...
        1 file(s) copied.
[1462549681.08][HTST][INF] starting host test process...
[1462549681.53][CONN][INF] starting connection process...
[1462549681.53][CONN][INF] initializing serial port listener...
[1462549681.53][SERI][INF] serial(port=COMx, baudrate=9600)
Plugin info: HostTestPluginBase::BasePlugin: Serial port for tid='0240000033514e450043500585d4003fe981000097969900' changed from 'COMx' to 'COM218'...
[1462549681.59][SERI][INF] serial port changed from 'COMx to 'COM218')
[1462549681.59][SERI][INF] reset device using 'default' plugin...
[1462549681.84][SERI][INF] wait for it...
[1462549682.84][CONN][INF] sending preamble '9cffc1bb-6a6c-4c4e-9fdc-350e7edb84d5'...
[1462549682.84][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1462549682.84][SERI][TXD] {{__sync;9cffc1bb-6a6c-4c4e-9fdc-350e7edb84d5}}
[1462549682.97][CONN][INF] found SYNC in stream: {{__sync;9cffc1bb-6a6c-4c4e-9fdc-350e7edb84d5}}, queued...
[1462549682.97][HTST][INF] sync KV found, uuid=9cffc1bb-6a6c-4c4e-9fdc-350e7edb84d5, timestamp=1462549682.975000
[1462549682.97][CONN][RXD] {{__sync;9cffc1bb-6a6c-4c4e-9fdc-350e7edb84d5}}
[1462549682.99][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
```