### PR TITLE
mbed-ls can return data for target id with wields like mount_point or serial_port set to None

### DIFF
--- a/mbed_host_tests/host_tests_plugins/host_test_plugins.py
+++ b/mbed_host_tests/host_tests_plugins/host_test_plugins.py
@@ -132,8 +132,10 @@ class HostTestPluginBase:
                 mbeds_by_tid = mbeds.list_mbeds_by_targetid()   # key: target_id, value mbedls_dict()
                 if target_id in mbeds_by_tid:
                     if 'mount_point' in mbeds_by_tid[target_id]:
-                        new_destination_disk = mbeds_by_tid[target_id]['mount_point']
-                        break
+                        if mbeds_by_tid[target_id]['mount_point']:
+                            # Only assign if mount point is known (not None)
+                            new_destination_disk = mbeds_by_tid[target_id]['mount_point']
+                            break
                 sleep(0.5)
 
             if new_destination_disk != destination_disk:
@@ -173,8 +175,10 @@ class HostTestPluginBase:
                 mbeds_by_tid = mbeds.list_mbeds_by_targetid()   # key: target_id, value mbedls_dict()
                 if target_id in mbeds_by_tid:
                     if 'serial_port' in mbeds_by_tid[target_id]:
-                        new_serial_port = mbeds_by_tid[target_id]['serial_port']
-                        break
+                        if mbeds_by_tid[target_id]['serial_port']:
+                            # Only assign if serial port is known (not None)
+                            new_serial_port = mbeds_by_tid[target_id]['serial_port']
+                            break
                 sleep(0.2)
 
             if new_serial_port != serial_port:


### PR DESCRIPTION
Changes:
* This patch makes sure we are not taking 'unknown' device property while pooling for it.
* Improvements for two previous PRs. See https://github.com/ARMmbed/htrun/pull/85 and https://github.com/ARMmbed/htrun/pull/86. 