### PR TITLE
Patch: serial port pooling time improvements (see #90)

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -255,6 +255,13 @@ def init_host_test_cli_params():
                       action="store_true",
                       help='Skips use of reset plugin. Note: target will not be reset')
 
+    parser.add_option('-P', '--pooling-timeout',
+                      dest='pooling_timeout',
+                      default=60,
+                      metavar="NUMBER",
+                      type="int",
+                      help='Timeout in sec for mbed-ls mount point and serial port readiness. Default 60 sec')
+
     parser.add_option('-b', '--send-break',
                       dest='send_break_cmd',
                       default=False,

--- a/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
@@ -74,6 +74,7 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
 
         # This optional parameter can be used if TargetID is provided (-t switch)
         target_id = kwargs.get('target_id', None)
+        pooling_timeout = kwargs.get('pooling_timeout', 60)
 
         result = False
         if self.check_parameters(capability, *args, **kwargs):
@@ -85,7 +86,7 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
                     # Wait for mount point to be ready
                     # if mount point changed according to target_id use new mount point
                     # available in result (_, destination_disk) of check_mount_point_ready
-                    mount_res, destination_disk = self.check_mount_point_ready(destination_disk, target_id=self.target_id)  # Blocking
+                    mount_res, destination_disk = self.check_mount_point_ready(destination_disk, target_id=self.target_id, timeout=pooling_timeout)  # Blocking
                     result = self.generic_mbed_copy(image_path, destination_disk)
         return result
 

--- a/mbed_host_tests/host_tests_plugins/module_copy_shell.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_shell.py
@@ -55,6 +55,7 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
 
         # This optional parameter can be used if TargetID is provided (-t switch)
         target_id = kwargs.get('target_id', None)
+        pooling_timeout = kwargs.get('pooling_timeout', 60)
 
         result = False
         if self.check_parameters(capability, *args, **kwargs):
@@ -64,7 +65,7 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
                 # Wait for mount point to be ready
                 # if mount point changed according to target_id use new mount point
                 # available in result (_, destination_disk) of check_mount_point_ready
-                mount_res, destination_disk = self.check_mount_point_ready(destination_disk, target_id=target_id)  # Blocking
+                mount_res, destination_disk = self.check_mount_point_ready(destination_disk, target_id=target_id, timeout=pooling_timeout)  # Blocking
                 # Prepare correct command line parameter values
                 image_base_name = basename(image_path)
                 destination_path = join(destination_disk, image_base_name)

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -111,7 +111,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "program_cycle_s" : self.options.program_cycle_s,
                 "reset_type" : self.options.forced_reset_type,
                 "target_id" : self.options.target_id,
-                "serial_pooling" : 60   # 60 sec timeout for serial port pooling
+                "serial_pooling" : self.options.pooling_timeout
             }
             # DUT-host communication process
             args = (event_queue, dut_event_queue, self.prn_lock, config)

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -110,7 +110,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "baudrate" : self.mbed.serial_baud,
                 "program_cycle_s" : self.options.program_cycle_s,
                 "reset_type" : self.options.forced_reset_type,
-                "target_id" : self.options.target_id
+                "target_id" : self.options.target_id,
+                "serial_pooling" : 60   # 60 sec timeout for serial port pooling
             }
             # DUT-host communication process
             args = (event_queue, dut_event_queue, self.prn_lock, config)

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -41,6 +41,7 @@ class Mbed:
         self.image_path = self.options.image_path.strip('"') if self.options.image_path is not None else ''
         self.copy_method = self.options.copy_method
         self.program_cycle_s = float(self.options.program_cycle_s if self.options.program_cycle_s is not None else 2.0)
+        self.pooling_timeout = self.options.pooling_timeout
 
         # Serial port settings
         self.serial_baud = 115200
@@ -106,12 +107,14 @@ class Mbed:
                 copy_method = 'shell'
         else:
             copy_method = 'shell'
+
         result = ht_plugins.call_plugin('CopyMethod',
                                         copy_method,
                                         image_path=image_path,
                                         serial=port,
                                         destination_disk=disk,
-                                        target_id=self.target_id)
+                                        target_id=self.target_id,
+                                        pooling_timeout=self.pooling_timeout)
         return result
 
     def hw_reset(self):


### PR DESCRIPTION
## Description
This is patch for:
  * Add serial port mount time discovery (with mbed-ls) delay to 1 minute, see #90.
  * Serial port mbed-ls guard failed, see #89
  * I've noticed wrong behavior with two previous PRs about serial port. When increasing pooling to >10 secs we will create timeout on event loop itself (its default timeout is 10 secs - wait for `__sync` and `__timeout` message from device).

Note:
* This PR will not allow us to remove switch `-C <sec>` which sets `program_cycle_s` - delay in seconds after we flash device. I've checked and removing it with this PR will cause errors such as "disk not ready" under Windows 7. 

## Changes
* Add default 60 sec timeout for event queue when we wait for serial port in conn_process.
  * This will expand event queue lifetime so it can wait for serial port pooling and capture oither events from preamble.
  * Note that we are sending `__timeout` event via event queue so we are not changing how preamble is parsed. When mount point / serial port is ready preamble from device comes and new `__timeout` is set and we can proceed with `__sync` packet and normal workflow.
* Add switch `-P <pooling_timeout_sec>`  to specify custom timeout for pooling procedures using `mbed-ls`.

Previously if waiting for serial port was longer than 10 secs (default timeout) we would not catch serial port mount after those 10 secs.

Additional event `__timeout` is sent to event queue to give it extra 60 secs of timeout so serial port pooling can finish:
```
[1462980474.74][HTST][INF] starting host test process...
[1462980475.31][CONN][INF] starting serial connection process...
[1462980475.31][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1462980475.31][CONN][INF] initializing serial port listener...
[1462980475.31][HTST][INF] setting timeout to: 60 sec
[1462980475.31][SERI][INF] serial(port=COM220, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000033514e45002e500585d4001ee981000097969900' serial port (current is 'COM220')...
[1462980475.34][SERI][INF] reset device using 'default' plugin...
[1462980475.58][SERI][INF] wait for it...
```

## Testing (using --skip-flashing)
### Serial not ready (device off)
```
$ mbedhtrun -d G: -p COM220:9600 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-ticker.bin" -C 4 -c shell -m K64F -t 0240000033514e45002e500585d4001ee981000097969900 -e "./test/host_tests" --skip-flashing
```
```
[1462982510.94][HTST][INF] host test executor ver. 0.2.10
[1462982510.94][HTST][INF] copy image onto target... SKIPPED!
[1462982510.94][HTST][INF] starting host test process...
[1462982511.55][CONN][INF] starting serial connection process...
[1462982511.55][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1462982511.56][CONN][INF] initializing serial port listener...
[1462982511.56][HTST][INF] setting timeout to: 60 sec
[1462982511.56][SERI][INF] serial(port=COM220, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000033514e45002e500585d4001ee981000097969900' serial port (current is 'COM220')...
[1462982571.57][HTST][INF] test suite run finished after 60.01 sec...
[1462982572.17][SERI][ERR] could not open port 'COM220': WindowsError(2, 'The system cannot find the file specified.')
[1462982572.17][CONN][INF] sending preamble '36c47fa9-1412-4fb2-9241-5c2587caab92'...
[1462982572.17][SERI][TXD] {{__sync;36c47fa9-1412-4fb2-9241-5c2587caab92}}
[1462982572.17][HTST][INF] CONN exited with code: 0
[1462982572.17][HTST][INF] Some events in queue
[1462982572.17][HTST][INF] stopped consuming events
[1462982572.17][HTST][INF] host test result(): None
[1462982572.17][HTST][WRN] missing __exit event from DUT
[1462982572.17][HTST][ERR] missing __exit event from DUT and no result from host test, timeout...
[1462982572.17][HTST][INF] calling blocking teardown()
[1462982572.17][HTST][INF] teardown() finished
[1462982572.17][HTST][INF] {{result;timeout}}
```
### Serial up after ~10 sec pooling for it
```
$ mbedhtrun -d G: -p COM220:9600 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-ticker.bin" -C 4 -c shell -m K64F -t 0240000033514e45002e500585d4001ee981000097969900 -e "./test/host_tests" --skip-flashing
```
```
[1462982695.69][HTST][INF] host test executor ver. 0.2.10
[1462982695.69][HTST][INF] copy image onto target... SKIPPED!
[1462982695.70][HTST][INF] starting host test process...
[1462982696.29][CONN][INF] starting serial connection process...
[1462982696.29][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1462982696.29][CONN][INF] initializing serial port listener...
[1462982696.29][HTST][INF] setting timeout to: 60 sec
[1462982696.29][SERI][INF] serial(port=COM220, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000033514e45002e500585d4001ee981000097969900' serial port (current is 'COM220')...
[1462982704.94][SERI][INF] reset device using 'default' plugin...
[1462982705.20][SERI][INF] wait for it...
[1462982706.21][CONN][INF] sending preamble '49010dfb-0215-4fb9-8d13-1f6d0713b8d9'...
[1462982706.21][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1462982706.21][SERI][TXD] {{__sync;49010dfb-0215-4fb9-8d13-1f6d0713b8d9}}
[1462982706.36][CONN][RXD] {{__sync;49010dfb-0215-4fb9-8d13-1f6d0713b8d9}}
[1462982706.36][CONN][INF] found SYNC in stream: {{__sync;49010dfb-0215-4fb9-8d13-1f6d0713b8d9}}, queued...
[1462982706.36][HTST][INF] sync KV found, uuid=49010dfb-0215-4fb9-8d13-1f6d0713b8d9, timestamp=1462982706.358000
[1462982706.36][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
[1462982706.36][CONN][RXD] {{__version;1.1.0}}
[1462982706.37][HTST][INF] DUT greentea-client version: 1.1.0
[1462982706.38][CONN][INF] found KV pair in stream: {{__timeout;20}}, queued...
[1462982706.38][HTST][INF] setting timeout to: 20 sec
[1462982706.38][CONN][RXD] {{__timeout;20}}
[1462982706.43][CONN][INF] found KV pair in stream: {{__host_test_name;wait_us_auto}}, queued...
[1462982706.43][HTST][INF] host test setup() call...
[1462982706.43][CONN][RXD] {{__host_test_name;wait_us_auto}}
[1462982706.43][HTST][INF] CALLBACKs updated
[1462982706.43][HTST][INF] host test detected: wait_us_auto
[1462982706.44][CONN][INF] found KV pair in stream: {{__testcase_count;1}}, queued...
[1462982706.44][CONN][RXD] {{__testcase_count;1}}
[1462982706.48][CONN][RXD] >>> Running 1 test cases..
```
### Serial on/off in the middle of KV protocol exchange
```
$ mbedhtrun -d G: -p COM220:9600 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-ticker.bin" -C 4 -c shell -m K64F -t 0240000033514e45002e500585d4001ee98100009
7969900 -e "./test/host_tests" --skip-flashing
```
```
[1462982452.19][HTST][INF] host test executor ver. 0.2.10
[1462982452.19][HTST][INF] copy image onto target... SKIPPED!
[1462982452.19][HTST][INF] starting host test process...
[1462982452.81][CONN][INF] starting serial connection process...
[1462982452.82][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1462982452.82][CONN][INF] initializing serial port listener...
[1462982452.82][HTST][INF] setting timeout to: 60 sec
[1462982452.82][SERI][INF] serial(port=COM220, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000033514e45002e500585d4001ee981000097969900' serial port (current is 'COM220')...
[1462982495.73][SERI][INF] reset device using 'default' plugin...
[1462982496.01][SERI][INF] wait for it...
[1462982497.00][CONN][INF] sending preamble 'a827ca98-b1da-43b0-9b7a-68fb44b84cbd'...
[1462982497.00][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1462982497.00][SERI][TXD] {{__sync;a827ca98-b1da-43b0-9b7a-68fb44b84cbd}}
[1462982497.15][CONN][INF] found SYNC in stream: {{__sync;a827ca98-b1da-43b0-9b7a-68fb44b84cbd}}, queued...
[1462982497.15][HTST][INF] sync KV found, uuid=a827ca98-b1da-43b0-9b7a-68fb44b84cbd, timestamp=1462982497.154000
[1462982497.16][CONN][RXD] {{__sync;a827ca98-b1da-43b0-9b7a-68fb44b84cbd}}
[1462982497.16][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
[1462982497.16][HTST][INF] DUT greentea-client version: 1.1.0
[1462982497.17][CONN][RXD] {{__version;1.1.0}}
[1462982497.20][CONN][INF] found KV pair in stream: {{__timeout;20}}, queued...
[1462982497.20][HTST][INF] setting timeout to: 20 sec
[1462982497.20][CONN][RXD] {{__timeout;20}}
[1462982497.23][CONN][INF] found KV pair in stream: {{__host_test_name;wait_us_auto}}, queued...
[1462982497.23][HTST][INF] host test setup() call...
[1462982497.23][CONN][RXD] {{__host_test_name;wait_us_auto}}
[1462982497.23][HTST][INF] CALLBACKs updated
[1462982497.23][HTST][INF] host test detected: wait_us_auto
[1462982497.24][CONN][INF] found KV pair in stream: {{__testcase_count;1}}, queued...
[1462982497.24][CONN][RXD] {{__testcase_count;1}}
[1462982497.29][CONN][RXD] >>> Running 1 test cases...
[1462982497.34][CONN][RXD] >>> Running case #1: 'Timers: 2 x tickers'...
[1462982497.36][CONN][INF] found KV pair in stream: {{__testcase_start;Timers: 2 x tickers}}, queued...
[1462982497.36][CONN][RXD] {{__testcase_start;Timers: 2 x tickers}}
[1462982498.37][CONN][INF] found KV pair in stream: {{tick;0}}, queued...
[1462982498.37][HTST][INF] tick! 1462982498.37
[1462982498.37][CONN][RXD] {{tick;0}}
[1462982499.37][CONN][INF] found KV pair in stream: {{tick;1}}, queued...
[1462982499.37][HTST][INF] tick! 1462982499.37
[1462982499.37][CONN][RXD] {{tick;1}}
[1462982501.03][SERI][ERR] call to ClearCommError failed
[1462982501.03][HTST][ERR] connection lost, serial.read(2048): call to ClearCommError failed
[1462982501.03][HTST][WRN] stopped to consume events due to __notify_conn_lost event
[1462982501.03][HTST][INF] test suite run finished after 3.83 sec...
[1462982501.10][HTST][INF] CONN exited with code: 0
[1462982501.10][HTST][INF] No events in queue
[1462982501.10][HTST][INF] host test result() call skipped, received: ioerr_serial
[1462982501.10][HTST][WRN] missing __exit event from DUT
[1462982501.10][HTST][INF] calling blocking teardown()
[1462982501.10][HTST][INF] teardown() finished
[1462982501.10][HTST][INF] {{result;ioerr_serial}}
```