### PR TITLE
Bug-fix: event queue hangs under RPI2

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -198,7 +198,7 @@ def conn_process(event_queue, dut_event_queue, prn_lock, config):
 
         # Send data to DUT
         try:
-            (key, value, _) = dut_event_queue.get(timeout=0)
+            (key, value, _) = dut_event_queue.get(timeout=1)
         except QueueEmpty:
             pass # Check if target sent something
         else:


### PR DESCRIPTION
Changes:
* Change `timeout` parameter for queue `dut_event_queue` to `1`.
* Tested with RPI2, Ubuntu 14 LTS and Windows 7. Packages tested: sal-test, mbed-drivers.
* This issue was 100% reproducible for RPI2 setup.
  * Issue found with bisect in `htrun` v0.2.9.

@mazimkhan Azim, please check and let me know if I can merge and release.
@bridadan FYI.