### PR TITLE
Bug-fix: If no ticks recorded host test returns True

### DIFF
--- a/mbed_host_tests/host_tests/wait_us_auto.py
+++ b/mbed_host_tests/host_tests/wait_us_auto.py
@@ -47,11 +47,15 @@ class WaitusTest(BaseHostTest):
             return deviation <= self.DEVIATION
 
         # Check if time between ticks was accurate
-        timestamps = [timestamp for _, _, timestamp in self.ticks]
-        self.log(str(timestamps))
-        m = map(sub_timestamps, timestamps[1:], timestamps[:-1])
-        self.log(str(m))
-        self.__result = all(m)
+        if self.ticks:
+            # If any ticks were recorded
+            timestamps = [timestamp for _, _, timestamp in self.ticks]
+            self.log(str(timestamps))
+            m = map(sub_timestamps, timestamps[1:], timestamps[:-1])
+            self.log(str(m))
+            self.__result = all(m)
+        else:
+            self.__result = False
         return self.__result
 
     def teardown(self):


### PR DESCRIPTION
Changes:
* Now if there are no ticks we will return False by default

## Example
In below example we will execute faulty ticker test where no ticks are outputed.
Host test (in case of no ticks) should return False.

### Before
```
[1464859336.01][SERI][TXD] {{__sync;1cb1979c-e353-4d3a-9d49-b20e68428174}}
[1464859337.02][CONN][RXD] {{__sync;1cb1979c-e353-4d3a-9d49-b20e68428174}}
[1464859337.02][CONN][RXD] {{__version;1.1.0}}
[1464859337.02][CONN][RXD] {{__timeout;20}}
[1464859337.02][CONN][RXD] {{__host_test_name;wait_us_auto}}
[1464859337.02][CONN][INF] found SYNC in stream: {{__sync;1cb1979c-e353-4d3a-9d49-b20e68428174}}, queued...
[1464859337.02][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
[1464859337.02][CONN][INF] found KV pair in stream: {{__timeout;20}}, queued...
[1464859337.02][HTST][INF] sync KV found, uuid=1cb1979c-e353-4d3a-9d49-b20e68428174, timestamp=1464859337.019000
[1464859337.02][CONN][INF] found KV pair in stream: {{__host_test_name;wait_us_auto}}, queued...
[1464859337.02][HTST][INF] DUT greentea-client version: 1.1.0
[1464859337.02][HTST][INF] setting timeout to: 20 sec
[1464859337.02][HTST][INF] host test setup() call...
[1464859337.02][HTST][INF] CALLBACKs updated
[1464859337.02][HTST][INF] host test detected: wait_us_auto
[1464859357.02][HTST][INF] test suite run finished after 20.00 sec...
[1464859357.04][CONN][INF] received special even '__host_test_finished' value='True', finishing
[1464859357.06][HTST][INF] CONN exited with code: 0
[1464859357.06][HTST][INF] No events in queue
[1464859357.06][HTST][INF] stopped consuming events
[1464859357.06][HTST][INF] host test result(): True
[1464859357.06][HTST][WRN] missing __exit event from DUT
[1464859357.06][HTST][INF] calling blocking teardown()
[1464859357.06][HTST][INF] teardown() finished
[1464859357.06][HTST][INF] {{result;success}}
```
### After
```
[1464862002.86][SERI][TXD] {{__sync;9df6752e-344e-492d-b71a-f9d730cfcf7b}}
[1464862003.87][CONN][RXD] {{__sync;9df6752e-344e-492d-b71a-f9d730cfcf7b}}
[1464862003.87][CONN][RXD] {{__version;1.1.0}}
[1464862003.87][CONN][RXD] {{__timeout;20}}
[1464862003.87][CONN][RXD] {{__host_test_name;wait_us_auto}}
[1464862003.87][CONN][INF] found SYNC in stream: {{__sync;9df6752e-344e-492d-b71a-f9d730cfcf7b}}, queued...
[1464862003.87][HTST][INF] sync KV found, uuid=9df6752e-344e-492d-b71a-f9d730cfcf7b, timestamp=1464862003.870000
[1464862003.87][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
[1464862003.87][HTST][INF] DUT greentea-client version: 1.1.0
[1464862003.87][CONN][INF] found KV pair in stream: {{__timeout;20}}, queued...
[1464862003.87][CONN][INF] found KV pair in stream: {{__host_test_name;wait_us_auto}}, queued...
[1464862003.87][HTST][INF] setting timeout to: 20 sec
[1464862003.87][HTST][INF] host test setup() call...
[1464862003.87][HTST][INF] CALLBACKs updated
[1464862003.87][HTST][INF] host test detected: wait_us_auto
[1464862023.87][HTST][INF] test suite run finished after 20.00 sec...
[1464862023.89][CONN][INF] received special even '__host_test_finished' value='True', finishing
[1464862023.91][HTST][INF] CONN exited with code: 0
[1464862023.91][HTST][INF] No events in queue
[1464862023.91][HTST][INF] stopped consuming events
[1464862023.91][HTST][INF] host test result(): False
[1464862023.91][HTST][WRN] missing __exit event from DUT
[1464862023.91][HTST][INF] calling blocking teardown()
[1464862023.91][HTST][INF] teardown() finished
[1464862023.91][HTST][INF] {{result;failure}}
```