### PR TITLE
Add table while printing to --list switch

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -98,10 +98,13 @@ def print_ht_list(verbose=False):
     """! Prints list of registered host test classes (by name)
         @Detail For devel & debug purposes
     """
+    from prettytable import PrettyTable
+    column_names = ['name', 'class', 'origin']
+    pt = PrettyTable(column_names)
+    for column in column_names:
+        pt.align[column] = 'l'
 
-    # Opiortunistic apporach
-    # If in yotta module top level dir try to list all
-    # tests in standard test/host_tests path
+    # Opiortunistic approach: always try to add current ./test/host_tests
     enum_host_tests('./test/host_tests', verbose=verbose)
 
     ht_str_len = 0
@@ -114,11 +117,9 @@ def print_ht_list(verbose=False):
     for ht in sorted(HOSTREGISTRY.HOST_TESTS.keys()):
         cls_str = str(HOSTREGISTRY.HOST_TESTS[ht].__class__)
         script_path_str = HOSTREGISTRY.HOST_TESTS[ht].script_location if HOSTREGISTRY.HOST_TESTS[ht].script_location else 'mbed-host-tests'
-
-        print "'%s'%s : %s()%s @ '%s'" % (ht, ' '*(ht_str_len - len(ht)),
-            cls_str,
-            ' '*(cls_str_len - len(cls_str)),
-            script_path_str)
+        row = [ht, cls_str, script_path_str]
+        pt.add_row(row)
+    print pt.get_string()
 
 def enum_host_tests(path, verbose=False):
     """ Enumerates and registers locally stored host tests


### PR DESCRIPTION
Example after change:
```
$ mbedhtrun --list
```
```
+-----------------------------+---------------------------------------------------------------------+------------------------------------------------------------------+
| name                        | class                                                               | origin                                                           |
+-----------------------------+---------------------------------------------------------------------+------------------------------------------------------------------+
| default                     | <class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>       | mbed-host-tests                                                  |
| default_auto                | <class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>       | mbed-host-tests                                                  |
| detect_auto                 | <class 'mbed_host_tests.host_tests.detect_auto.DetectPlatformTest'> | mbed-host-tests                                                  |
| dev_null_auto               | <class 'mbed_host_tests.host_tests.dev_null_auto.DevNullTest'>      | mbed-host-tests                                                  |
| echo                        | <class 'mbed_host_tests.host_tests.echo.EchoTest'>                  | mbed-host-tests                                                  |
| hello_auto                  | <class 'mbed_host_tests.host_tests.hello_auto.HelloTest'>           | mbed-host-tests                                                  |
| n_channel_tcp_echo_client   | <class 'n_channel_tcp_echo_client.TCPEchoClientTest'>               | c:\Work\socket-test\test\host_tests\n_channel_tcp_echo_client.py |
| rtc_auto                    | <class 'mbed_host_tests.host_tests.rtc_auto.RTCTest'>               | mbed-host-tests                                                  |
| sockets_tcp_udp_echo_server | <class 'tcp_udp_echo_server.TcpUdpEchoServer'>                      | c:\Work\socket-test\test\host_tests\tcp_udp_echo_server.py       |
| tcp_echo_client             | <class 'tcp_echo_client.TCPEchoClientTest'>                         | c:\Work\socket-test\test\host_tests\tcp_echo_client.py           |
| tcp_echo_server             | <class 'tcp_echo_server.TCPEchoServerTest'>                         | c:\Work\socket-test\test\host_tests\tcp_echo_server.py           |
| udp_echo_client             | <class 'udp_echo_client.UDPEchoClientTest'>                         | c:\Work\socket-test\test\host_tests\udp_echo_client.py           |
| udp_echo_server             | <class 'udp_echo_server.UdpEchoServer'>                             | c:\Work\socket-test\test\host_tests\udp_echo_server.py           |
| wait_us_auto                | <class 'mbed_host_tests.host_tests.wait_us_auto.WaitusTest'>        | mbed-host-tests                                                  |
+-----------------------------+---------------------------------------------------------------------+------------------------------------------------------------------+
```