### PR TITLE
Add back support for -R <timeout-after-reset> command line switch

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -215,7 +215,7 @@ def init_host_test_cli_params():
     parser.add_option("-R", "--reset-timeout",
                       dest="forced_reset_timeout",
                       metavar="NUMBER",
-                      type="int",
+                      type="float",
                       help="When forcing a reset using option -r you can set up after reset idle delay in seconds")
 
     parser.add_option("-e", "--enum-host-tests",

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -37,6 +37,7 @@ class SerialConnectorPrimitive(object):
         self.LAST_ERROR = None
         self.target_id = self.config.get('target_id', None)
         self.serial_pooling = config.get('serial_pooling', 60)
+        self.forced_reset_timeout = config.get('forced_reset_timeout', 1)
 
         # Values used to call serial port listener...
         self.logger.prn_inf("serial(port=%s, baudrate=%d, timeout=%s)"% (self.port, self.baudrate, self.timeout))
@@ -63,7 +64,7 @@ class SerialConnectorPrimitive(object):
                 str(e))
             self.logger.prn_err(str(e))
         else:
-            self.reset_dev_via_serial()
+            self.reset_dev_via_serial(delay=self.forced_reset_timeout)
 
     def reset_dev_via_serial(self, delay=1):
         """! Reset device using selected method, calls one of the reset plugins """
@@ -79,8 +80,10 @@ class SerialConnectorPrimitive(object):
             disk=disk,
             target_id=self.target_id)
         # Post-reset sleep
+        if delay:
+            self.logger.prn_inf("waiting %.2f sec after reset"% delay)
+            sleep(delay)
         self.logger.prn_inf("wait for it...")
-        sleep(delay)
         return result
 
     def read(self, count):

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -143,7 +143,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "program_cycle_s" : self.options.program_cycle_s,
                 "reset_type" : self.options.forced_reset_type,
                 "target_id" : self.options.target_id,
-                "serial_pooling" : self.options.pooling_timeout
+                "serial_pooling" : self.options.pooling_timeout,
+                "forced_reset_timeout" : self.options.forced_reset_timeout
             }
             # DUT-host communication process
             args = (event_queue, dut_event_queue, self.prn_lock, config)


### PR DESCRIPTION
Changes:
* Switch `-R` was not supported in new event loop `CONN` process.
