### PR TITLE
Re-adds the default reset timeout of 1 second

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -214,9 +214,10 @@ def init_host_test_cli_params():
 
     parser.add_option("-R", "--reset-timeout",
                       dest="forced_reset_timeout",
+                      default=1,
                       metavar="NUMBER",
                       type="float",
-                      help="When forcing a reset using option -r you can set up after reset idle delay in seconds")
+                      help="When forcing a reset using option -r you can set up after reset idle delay in seconds (Default is 1 second)")
 
     parser.add_option("-e", "--enum-host-tests",
                       dest="enum_host_tests",


### PR DESCRIPTION
When PR #98 was merged (867e83072651c756649c8ef4a926a2700b191b3b), the default value of 1 second for `forced_reset_timeout` was incorrectly removed. Instead it was being set to `None`, which caused targets to not sync correctly.

This PR adds the default of 1 second back to the `forced_reset_timeout` option.

## Before
```
mbedgt: selecting test case observer...
        calling mbedhtrun: mbedhtrun -d D: -p COM249:9600 -f "C:\m\test\.build\tests\RZ_A1H\GCC_ARM\mbed-os\TESTS\mbed_drivers\rtc\mbed-os-tests-mbed_
drivers-rtc.bin" -C 2 -c shell -m RZ_A1H -t 550002210FB3423630F7860B
mbedgt: mbed-host-test-runner: started
[1465986552.61][HTST][INF] host test executor ver. 0.2.15
[1465986552.61][HTST][INF] copy image onto target...
        1 file(s) copied.
Plugin info: HostTestPluginCopyMethod_Shell::CopyMethod: Waiting up to 60 sec for '550002210FB3423630F7860B' mount point (current is 'D:')...
[1465986561.55][HTST][INF] starting host test process...
[1465986562.09][CONN][INF] starting serial connection process...
[1465986562.09][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1465986562.09][CONN][INF] initializing serial port listener...
[1465986562.09][HTST][INF] setting timeout to: 60 sec
forced_reset_timeout None
[1465986562.09][SERI][INF] serial(port=COM249, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '550002210FB3423630F7860B' serial port (current is 'COM249')...
[1465986562.16][SERI][INF] reset device using 'default' plugin...
[1465986562.42][SERI][INF] wait for it...
[1465986562.42][CONN][INF] sending preamble '2647c51b-bd6b-429e-a289-e347cd62a166'...
[1465986562.42][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1465986562.42][SERI][TXD] {{__sync;2647c51b-bd6b-429e-a289-e347cd62a166}}
[1465986622.09][HTST][INF] test suite run finished after 60.00 sec...
[1465986622.09][CONN][INF] received special even '__host_test_finished' value='True', finishing
[1465986622.10][HTST][INF] CONN exited with code: 0
[1465986622.10][HTST][INF] No events in queue
[1465986622.10][HTST][INF] stopped consuming events
[1465986622.10][HTST][INF] host test result(): None
[1465986622.10][HTST][WRN] missing __exit event from DUT
[1465986622.10][HTST][ERR] missing __exit event from DUT and no result from host test, timeout...
[1465986622.10][HTST][INF] calling blocking teardown()
[1465986622.10][HTST][INF] teardown() finished
[1465986622.10][HTST][INF] {{result;timeout}}
```

## After
```
mbedgt: mbed-host-test-runner: started
[1465987989.44][HTST][INF] host test executor ver. 0.2.15
[1465987989.44][HTST][INF] copy image onto target...
        1 file(s) copied.
Plugin info: HostTestPluginCopyMethod_Shell::CopyMethod: Waiting up to 60 sec for '550002210FB3423630F7860B' mount point (current is 'D:')...
[1465988002.67][HTST][INF] starting host test process...
[1465988003.04][CONN][INF] starting serial connection process...
[1465988003.04][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1465988003.04][CONN][INF] initializing serial port listener...
[1465988003.04][HTST][INF] setting timeout to: 60 sec
[1465988003.04][SERI][INF] serial(port=COM249, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '550002210FB3423630F7860B' serial port (current is 'COM249')...
[1465988003.23][SERI][INF] reset device using 'default' plugin...
[1465988003.48][SERI][INF] waiting 1.00 sec after reset
[1465988004.48][SERI][INF] wait for it...
[1465988004.48][CONN][INF] sending preamble 'ab1480c4-aa29-4f62-b567-65c0841f31f4'...
[1465988004.48][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1465988004.48][SERI][TXD] {{__sync;ab1480c4-aa29-4f62-b567-65c0841f31f4}}
[1465988004.62][CONN][INF] found SYNC in stream: {{__sync;ab1480c4-aa29-4f62-b567-65c0841f31f4}}, queued...
[1465988004.62][HTST][INF] sync KV found, uuid=ab1480c4-aa29-4f62-b567-65c0841f31f4, timestamp=1465988004.624000
[1465988004.62][CONN][RXD] {{__sync;ab1480c4-aa29-4f62-b567-65c0841f31f4}}
[1465988004.64][CONN][INF] found KV pair in stream: {{__version;1.2.0}}, queued...
[1465988004.64][HTST][INF] DUT greentea-client version: 1.2.0
[1465988004.65][CONN][RXD] {{__version;1.2.0}}
[1465988004.66][CONN][INF] found KV pair in stream: {{__timeout;20}}, queued...
[1465988004.66][HTST][INF] setting timeout to: 20 sec
[1465988004.66][CONN][RXD] {{__timeout;20}}
[1465988004.70][CONN][INF] found KV pair in stream: {{__host_test_name;default_auto}}, queued...
[1465988004.70][HTST][INF] host test class: '<class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>'
[1465988004.70][HTST][INF] host test setup() call...
[1465988004.70][HTST][INF] CALLBACKs updated
[1465988004.70][HTST][INF] host test detected: default_auto
[1465988004.70][CONN][RXD] {{__host_test_name;default_auto}}
[1465988007.24][CONN][RXD] TCP client IP Address is 10.254.2.234
...[SNIP]...
[1465988008.28][HTST][INF] {{result;success}}
```