### PR TITLE
Add new switch --sync to manipulate how many times htrun should send __sync to target platform

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -188,6 +188,13 @@ def init_host_test_cli_params():
                       help="Unique Target Id or mbed platform",
                       metavar="TARGET_ID")
 
+    parser.add_option("", "--sync",
+                      dest="sync_behavior",
+                      default=2,
+                      type=int,
+                      help="Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of times (Default 2 time)",
+                      metavar="SYNC_BEHAVIOR")
+
     parser.add_option("-f", "--image-path",
                       dest="image_path",
                       help="Path with target's binary image",

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -144,7 +144,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "reset_type" : self.options.forced_reset_type,
                 "target_id" : self.options.target_id,
                 "serial_pooling" : self.options.pooling_timeout,
-                "forced_reset_timeout" : self.options.forced_reset_timeout
+                "forced_reset_timeout" : self.options.forced_reset_timeout,
+                "sync_behavior" : self.options.sync_behavior
             }
             # DUT-host communication process
             args = (event_queue, dut_event_queue, self.prn_lock, config)


### PR DESCRIPTION
### Description

Sync packet management allows us to manipulate the way `htrun` sends `__sync` packet(s).
With current settings we can force on `htrun` to send `__sync` packets in this manner:

```
 * --sync=0        - No sync packets will be sent to target platform
```
```
 * --sync=-1       - __sync packets will be sent unless we will reach
                     timeout or proper response is sent from target platform
```
``` 
* --sync=N        - Send up to N __sync packets to target platform. Response
                     is sent unless we get response from target platform or
                     timeout occur
```

### Example
```
mbedhtrun ... --sync=3 ... --skip-flashing
```
```
[1466093139.60][HTST][INF] host test executor ver. 0.2.17
[1466093139.60][HTST][INF] copy image onto target... SKIPPED!
[1466093139.61][HTST][INF] starting host test process...
[1466093140.26][CONN][INF] starting serial connection process...
[1466093140.26][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1466093140.26][CONN][INF] initializing serial port listener...
[1466093140.26][HTST][INF] setting timeout to: 60 sec
[1466093140.26][SERI][INF] serial(port=COM239, baudrate=115200, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000034544e45002600048e3800285a91000097969900' serial port (current is 'COM239')...
[1466093140.29][SERI][INF] reset device using 'default' plugin...
[1466093140.54][SERI][INF] waiting 1.00 sec after reset
[1466093141.54][SERI][INF] wait for it...
[1466093141.54][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1466093141.54][CONN][INF] sending up to 3 __sync packets (specified with --sync=3)
[1466093141.54][CONN][INF] sending preamble '82bb204f-c5a5-4b5b-8ee9-deec3dbc2979'
[1466093141.54][SERI][TXD] {{__sync;82bb204f-c5a5-4b5b-8ee9-deec3dbc2979}}
[1466093142.55][CONN][INF] resending new preamble 'ca8a51c2-ec57-4512-b17f-e607b45fb1d6' after 1.01 sec
[1466093142.55][SERI][TXD] {{__sync;ca8a51c2-ec57-4512-b17f-e607b45fb1d6}}
[1466093143.56][CONN][INF] resending new preamble '73ced30b-cc01-412b-bccf-c92d859a02a9' after 1.01 sec
[1466093143.56][SERI][TXD] {{__sync;73ced30b-cc01-412b-bccf-c92d859a02a9}}
```