### PR TITLE
Converted HtrunLogger to use Python 'logging' module removing custom lock

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -28,10 +28,9 @@ from conn_proxy_logger import HtrunLogger
 
 class ConnectorPrimitive(object):
 
-    def __init__(self, name, prn_lock):
+    def __init__(self, name):
         self.LAST_ERROR = None
-        self.prn_lock = prn_lock
-        self.logger = HtrunLogger(prn_lock, name)
+        self.logger = HtrunLogger(name)
 
     def write_kv(self, key, value):
         kv_buff = "{{%s;%s}}\n"% (key, value)
@@ -59,12 +58,11 @@ class ConnectorPrimitive(object):
 
 
 class SerialConnectorPrimitive(ConnectorPrimitive):
-    def __init__(self, name, port, baudrate, prn_lock, config):
-        ConnectorPrimitive.__init__(self, name, prn_lock)
+    def __init__(self, name, port, baudrate, config):
+        ConnectorPrimitive.__init__(self, name)
         self.port = port
         self.baudrate = int(baudrate)
         self.timeout = 0
-        self.prn_lock = prn_lock
         self.config = config
         self.target_id = self.config.get('target_id', None)
         self.serial_pooling = config.get('serial_pooling', 60)
@@ -182,9 +180,9 @@ class KiViBufferWalker():
         return (key, value, time())
 
 
-def conn_process(event_queue, dut_event_queue, prn_lock, config):
+def conn_process(event_queue, dut_event_queue, config):
 
-    logger = HtrunLogger(prn_lock, 'CONN')
+    logger = HtrunLogger('CONN')
     logger.prn_inf("starting serial connection process...")
 
     port = config.get('port')
@@ -202,7 +200,6 @@ def conn_process(event_queue, dut_event_queue, prn_lock, config):
         'SERI',
         port,
         baudrate,
-        prn_lock,
         config=config)
 
     kv_buffer = KiViBufferWalker()

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy_logger.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy_logger.py
@@ -18,54 +18,33 @@ limitations under the License.
 
 
 import sys
+import logging
 from time import time
 
 
 class HtrunLogger(object):
     """! Yet another logger flavour """
-    def __init__(self, prn_lock, name):
-        self.__prn_lock = prn_lock
-        self.__name = name
-
-    def __prn_func(self, text, nl=True):
-        """! Prints and flushes data to stdout """
-        with self.__prn_lock:
-            if nl and not text.endswith('\n'):
-                text += '\n'
-            sys.stdout.write(text)
-            sys.stdout.flush()
-
-    def __prn_log_human(self, level, text, timestamp=None):
-        if not timestamp:
-            timestamp = time()
-        timestamp_str = strftime("%y-%m-%d %H:%M:%S", gmtime(timestamp))
-        frac, whole = modf(timestamp)
-        s = "[%s.%d][%s][%s] %s"% (timestamp_str, frac, self.__name, level, text)
-        self.__prn_func(s, nl=True)
-
-    def __prn_log(self, level, text, timestamp=None):
-        if not timestamp:
-            timestamp = time()
-        s = "[%.2f][%s][%s] %s"% (timestamp, self.__name, level, text)
-        self.__prn_func(s, nl=True)
+    def __init__(self, name):
+        logging.basicConfig(stream=sys.stdout,format='[%(created).2f][%(name)s][%(logger_level)s] %(message)s', level=logging.DEBUG)
+        self.logger = logging.getLogger(name)
 
     def prn_dbg(self, text, timestamp=None):
-        self.__prn_log('DBG', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'DBG'})
 
     def prn_wrn(self, text, timestamp=None):
-        self.__prn_log('WRN', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'WRN'})
 
     def prn_err(self, text, timestamp=None):
-        self.__prn_log('ERR', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'ERR'})
 
     def prn_inf(self, text, timestamp=None):
-        self.__prn_log('INF', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'INF'})
 
     def prn_txt(self, text, timestamp=None):
-        self.__prn_log('TXT', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'TXT'})
 
     def prn_txd(self, text, timestamp=None):
-        self.__prn_log('TXD', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'TXD'})
 
     def prn_rxd(self, text, timestamp=None):
-        self.__prn_log('RXD', text, timestamp)
+        self.logger.debug(text, extra={'logger_level': 'RXD'})

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -44,8 +44,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         """
         self.options = options
 
-        self.prn_lock = Lock()
-        self.logger = HtrunLogger(self.prn_lock, 'HTST')
+        self.logger = HtrunLogger('HTST')
 
         # Handle extra command from
         if options:
@@ -148,7 +147,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "sync_behavior" : self.options.sync_behavior
             }
             # DUT-host communication process
-            args = (event_queue, dut_event_queue, self.prn_lock, config)
+            args = (event_queue, dut_event_queue, config)
             p = Process(target=conn_process, args=args)
             p.deamon = True
             p.start()


### PR DESCRIPTION
Adaption of the 'HtrunLogger' class to replace the custom outputting to stdout, with the builtin 'logging' module in Python. Now all of the logging will go through the 'logging' module, and will be formatted in the same way as before. Further iterations will fully remove the class, and rely solely on calling the logging code. The issue for this enhancement is #102.

@adbridge 
@mazimkhan 
@PrzemekWirkus 