### PR TITLE
Changing the key-value pair regex to include searches for new line

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -158,7 +158,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
 class KiViBufferWalker():
     """! Simple auxiliary class used to walk through a buffer and search for KV tokens """
     def __init__(self):
-        self.KIVI_REGEX = r"\{\{([\w\d_-]+);([^\}]+)\}\}"
+        self.KIVI_REGEX = r"\{\{([\w\d_-]+);([^\}]+)\}\}\n"
         self.buff = str()
         self.buff_idx = 0
         self.re_kv = re.compile(self.KIVI_REGEX)


### PR DESCRIPTION
This is in response to the ongoing discussion about this DAPLink issue: https://github.com/mbedmicro/DAPLink/issues/115

The behavior that reveal the issue in DAPLink was the following:
1) The device sends a key value pair: `{{key;value}}\n`
2) The host receives the serial data character-by-character.
3) `KiViBufferWalker` matches a key-value pair with the regex `\{\{([\w\d_-]+);([^\}]+)\}\}`, which does not wait for the new the newline of the key-value pair: `{{key;value}}` (note no `\n`).
4) The host immediately sends a new key-value pair to the device. At this time the device is still sending the `\n` character.
5) The device is now receiving a character and attempting to transmit a character at the same time. The particular timing of this case causes a race conditions, which puts DAPLink into a bad state.

This patch forces the host test runner to wait for the `\n` character before matching any key-value pairs. This doesn't prevent every case where DAPLink might get into a bad state, but it avoids the particular case described above.

@PrzemekWirkus @mazimkhan @adbridge 

For more intimate details on the DAPLink issue, please see Russ's commit message on his proposed patch here: https://github.com/mbedmicro/DAPLink/pull/97/commits/1dcc1b104ab9ca8b500e51657a5ae83d003ba2e3