### PR TITLE
Add back wrongly removed '\n' K-V pair sent to the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Key-value protocol was developed and is used to provide communication layer betw
 ## Design draft
 * Simple key-value protocol is introduced. It is used to communicate between DUT and host. Protocol main features:
 * Protocol introduced is master-slave protocol, where master is host and slave is device under test.
-* Transport layer consist of simple ```{{KEY;VALUE}}}``` messages sent by slave (DUT). Both key and value are strings with allowed character set limitations (to simplify parsing and protocol parser itself).
+* Transport layer consist of simple ```{{ KEY ; VALUE }} \n``` text messages sent by slave (DUT). Both key and value are strings with allowed character set limitations (to simplify parsing and protocol parser itself). Message ends with required by DUT K-V parser `\n` character.
 * DUT always (except for handshake phase) initializes communication by sending key-value message to host.
 * To avoid miscommunication between master and slave simple handshake protocol is introduces:
     * Master (host) sends sync packet: ```{{__sync;UUID-STRING}}}``` with message value containing random UUID string.

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -33,9 +33,15 @@ class ConnectorPrimitive(object):
         self.logger = HtrunLogger(name)
 
     def write_kv(self, key, value):
-        kv_buff = "{{%s;%s}}"% (key, value)
+        """! Forms and sends Key-Value protocol message.
+        @details On how to parse K-V sent from DUT see KiViBufferWalker::KIVI_REGEX
+                 On how DUT sends K-V please see greentea_write_postamble() function in greentea-client
+        @return Returns buffer with K-V message sent to DUT
+        """
+        # All Key-Value messages ends with newline character
+        kv_buff = "{{%s;%s}}"% (key, value) + '\n'
         self.write(kv_buff)
-        self.logger.prn_txd(kv_buff)
+        self.logger.prn_txd(kv_buff.rstrip())
         return kv_buff
 
     def read(self, count):


### PR DESCRIPTION
# Changes
Align how DUT and host together send and receive K-V messages between each other.

* Together with #104 should significantly improve e.g, mbed_drivers::echo tests and DAPLink UX
* While sending (TXD) K-V from `htrun` logger will not print white-space characters new line at the end
* Updated `README` to reflect missing `\n` in K-V format
* Note that `greentea-client` will always send newline character to host, see [here](https://github.com/ARMmbed/greentea-client/blob/master/source/test_env.cpp#L211).

# Testting
```
mbedgt: test suite report:
+--------------+---------------+-------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite              | result | elapsed_time (sec) | copy_method |
+--------------+---------------+-------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-echo | OK     | 23.73              | shell       |
+--------------+---------------+-------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+--------------+---------------+-------------------------+------------------+--------+--------+--------+--------------------+
| target       | platform_name | test suite              | test case        | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+-------------------------+------------------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-echo | Echo server: x16 | 1      | 0      | OK     | 1.65               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-echo | Echo server: x32 | 1      | 0      | OK     | 3.19               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-echo | Echo server: x64 | 1      | 0      | OK     | 6.29               |
+--------------+---------------+-------------------------+------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 3 OK
mbedgt: completed in 23.82 sec
```