### PR TITLE
Add new event name __testcase_name

### DIFF
--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -121,6 +121,7 @@ class HostTestCallbackBase(BaseHostTestAbstract):
             '__testcase_start',
             '__testcase_finish',
             '__testcase_count',
+            '__testcase_name',
             '__testcase_summary',
             '__rxd_line',
         ]


### PR DESCRIPTION
Changes:
* This event is available in `greentea-client v1.3.0`
* `__testcase_name` event passes from `utest` to Greentea information about all test case names available
* Impact:
  * mbed-os: [ Provide list of test case names to greentea prior to running test. #1 ](https://github.com/adbridge/mbed-os/pull/1)
  * Greentea: [Add support for SKIPPED test cases #158 ](https://github.com/ARMmbed/greentea/pull/158)
  * greentea-client: [Add new key "__testcase_name". #15 ](https://github.com/ARMmbed/greentea-client/pull/15)