### PR TITLE
Turn down the logging noise.

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -291,7 +291,7 @@ def init_host_test_cli_params():
                       dest='logging_level',
                       type='choice',
                       choices=['error', 'warning', 'info', 'debug'],
-                      default='debug',
+                      default='error',
                       action='store',
                       help='Increase logging verbosity')
 

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -287,6 +287,14 @@ def init_host_test_cli_params():
                       action="store_true",
                       help='More verbose mode')
 
+    parser.add_option('--logging-level',
+                      dest='logging_level',
+                      type='choice',
+                      choices=['error', 'warning', 'info', 'debug'],
+                      default='debug',
+                      action='store',
+                      help='Increase logging verbosity')
+
     parser.add_option('', '--version',
                       dest='version',
                       default=False,

--- a/mbed_host_tests/host_tests_logger/ht_logger.py
+++ b/mbed_host_tests/host_tests_logger/ht_logger.py
@@ -25,7 +25,7 @@ from functools import partial
 class HtrunLogger(object):
     """! Yet another logger flavour """
     def __init__(self, name):
-        logging.basicConfig(stream=sys.stdout,format='[%(created).2f][%(name)s]%(message)s', level=logging.DEBUG)
+        logging.basicConfig(stream=sys.stderr, format='[%(created).2f][%(name)s]%(message)s', level=logging.DEBUG)
         self.logger = logging.getLogger("HTRUN." + name)
         self.format_str = '[%(logger_level)s] %(message)s'
 

--- a/mbed_host_tests/host_tests_logger/ht_logger.py
+++ b/mbed_host_tests/host_tests_logger/ht_logger.py
@@ -26,7 +26,7 @@ class HtrunLogger(object):
     """! Yet another logger flavour """
     def __init__(self, name):
         logging.basicConfig(stream=sys.stdout,format='[%(created).2f][%(name)s]%(message)s', level=logging.DEBUG)
-        self.logger = logging.getLogger(name)
+        self.logger = logging.getLogger("HTRUN." + name)
         self.format_str = '[%(logger_level)s] %(message)s'
 
         def __prn_log(self, logger_level, text, timestamp=None):

--- a/mbed_host_tests/mbedhtrun.py
+++ b/mbed_host_tests/mbedhtrun.py
@@ -21,6 +21,7 @@ from multiprocessing import freeze_support
 from mbed_host_tests import init_host_test_cli_params
 from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
 
+import logging
 
 def main():
     """! This function drives command line tool 'mbedhtrun' which is using DefaultTestSelector
@@ -29,7 +30,18 @@ def main():
     """
     freeze_support()
     result = -2
-    test_selector = DefaultTestSelector(init_host_test_cli_params())
+    options = init_host_test_cli_params()
+
+    level = logging.ERROR
+    level_map = {
+        "error": logging.ERROR,
+        "warning": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG
+    }
+
+    logging.getLogger("HTRUN").setLevel(level_map[options.logging_level])
+    test_selector = DefaultTestSelector(options)
     try:
         result = test_selector.execute()
     except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
This set of patches taken together move the logging stream from stdout to stderr and turn the volume down slightly, defaulting to errors only.

We add a new option to allow the log level to be set on the command line.

