### PR TITLE
Fixing issue with multiprocess Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Key-value protocol was developed and is used to provide communication layer betw
       * ```__testcase_start``` - sent by DUT, test case start data.
       * ```__testcase_finish``` - sent by DUT, test case result.
       * ```__exit``` - sent by DUT, test suite execution finished.
+      * ```__exit_event_queue``` - sent by host test, indicating no more events expected.
   * Non-Reserved event/message keys have leading ```__``` in name:
     * ```__rxd_line``` - Event triggered when ```\n``` was found on DUT RXD channel. It can be overridden (```self.register_callback('__rxd_line', <callback_function>)```) and used by user. Event is sent by host test to notify a new line of text was received on RXD channel. ```__rxd_line``` event payload (value) in a line of text received from DUT over RXD.
 * Each host test (master side) has four functions used by async framework:

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -114,6 +114,7 @@ class HostTestCallbackBase(BaseHostTestAbstract):
             '__testcase_finish',
             '__testcase_summary',
             '__exit',
+            '__exit_event_queue'
         ]
 
         self.__consume_by_default = [

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -366,7 +366,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         #if not callbacks__exit_event_queue and not result:
         if not callbacks__exit_event_queue and result is None:
-            self.logger.prn_err("missing __exit_event_queue event from host test and no result from host test, timeout...")
+            self.logger.prn_err("missing __exit_event_queue event from " + \
+                "host test and no result from host test, timeout...")
             result = self.RESULT_TIMEOUT
 
         self.logger.prn_inf("calling blocking teardown()")


### PR DESCRIPTION
### STATUS: NEEDS TESTING (HOLD OFF ON MERGE FOR NOW)
#### I will update this PR with results after running this in CI for sometime

This commit fixes an intermittent failure with the multiprocess Queue used
within the host test. There is a chance that a Queue will return that it
is empty even if an item has been added to it (see the Queue documentation
here:
https://docs.python.org/2/library/multiprocessing.html#pipes-and-queues).
This issue intermittently arrises in the following scenario:

- A DUT sends the {{end;success}} KV pair
- A DUT sends the {{__exit;0}} KV pair
- The {{end;success}} KV pair is pulled from the queue, which puts a
  callback for notify_complete to be called (after the __exit KV pair)
- The {{__exit;0}} KV pair is pulled from the queue, which breaks out of
  the loop
- The queue is checked to see if it is empty. This is the intermittent
  point of failure, as this sometimes returns True even though there
  should be a notify_compelte KV pair in the queue
- Since the queue is presumed to be empty, the result isn't properly
  updated and the test fails incorrectly

The fix for this is not to break out of the queue loop on __exit or on any
other KV pair or error condition. Instead, replace these 'break'
statements with another queue event called '__exit_event_queue'. This is
the only event that will call 'break'. The rule for this event is that **it
will always be the last event in the queue**. Since the Queue.empty()
function cannot be trusted, this is used instead to mark the end of the
host test execution.

This solution was inspired by the blog post here:
http://bryceboe.com/2011/01/28/the-python-multiprocessing-queue-and-large-objects/

cc @mazimkhan @ConorPKeegan 