### PR TITLE
Serial write timeout

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
@@ -37,13 +37,17 @@ class ConnectorPrimitive(object):
         """! Forms and sends Key-Value protocol message.
         @details On how to parse K-V sent from DUT see KiViBufferWalker::KIVI_REGEX
                  On how DUT sends K-V please see greentea_write_postamble() function in greentea-client
-        @return Returns buffer with K-V message sent to DUT
+        @return Returns buffer with K-V message sent to DUT on success, None on failure
         """
         # All Key-Value messages ends with newline character
         kv_buff = "{{%s;%s}}"% (key, value) + '\n'
-        self.write(kv_buff)
-        self.logger.prn_txd(kv_buff.rstrip())
-        return kv_buff
+        written_kv_buff = self.write(kv_buff)
+
+        if kv_buff == written_kv_buff:
+            self.logger.prn_txd(kv_buff.rstrip())
+            return kv_buff
+        else:
+            return None
 
     def read(self, count):
         """! Read data from DUT

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
@@ -41,9 +41,8 @@ class ConnectorPrimitive(object):
         """
         # All Key-Value messages ends with newline character
         kv_buff = "{{%s;%s}}"% (key, value) + '\n'
-        written_kv_buff = self.write(kv_buff)
 
-        if kv_buff == written_kv_buff:
+        if self.write(kv_buff):
             self.logger.prn_txd(kv_buff.rstrip())
             return kv_buff
         else:

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -124,7 +124,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
             self.selected_resource.write(payload)
             if log:
                 self.logger.prn_txd(payload)
-        return payload
+        return True
 
     def flush(self):
         pass

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -100,7 +100,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         """! Read data from serial port RX buffer """
         # TIMEOUT: Since read is called in a loop, wait for self.timeout period before calling serial.read(). See
         # comment on serial.Serial() call above about timeout.
-        time.sleep(self.timeout)
+        time.sleep(self.read_timeout)
         c = str()
         try:
             if self.serial:

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -118,11 +118,11 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
                 self.serial.write(payload)
                 if log:
                     self.logger.prn_txd(payload)
+                return payload
         except SerialException as e:
             self.serial = None
             self.LAST_ERROR = "connection lost, serial.write(%d bytes): %s"% (len(payload), str(e))
             self.logger.prn_err(str(e))
-        return payload
 
     def flush(self):
         if self.serial:

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -29,15 +29,14 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         ConnectorPrimitive.__init__(self, name)
         self.port = port
         self.baudrate = int(baudrate)
-        self.timeout = 0.01  # 10 milli sec
+        self.read_timeout = 0.01  # 10 milli sec
+        self.write_timeout = 5
         self.config = config
         self.target_id = self.config.get('target_id', None)
         self.polling_timeout = config.get('polling_timeout', 60)
         self.forced_reset_timeout = config.get('forced_reset_timeout', 1)
         self.skip_reset = config.get('skip_reset', False)
         self.serial = None
-
-        # Values used to call serial port listener...
 
         # Check if serial port for given target_id changed
         # If it does we will use new port to open connections and make sure reset plugin
@@ -55,18 +54,19 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
             self.port = serial_port
 
         startTime = time.time()
-        self.logger.prn_inf("serial(port=%s, baudrate=%d, timeout=%s)"% (self.port, self.baudrate, self.timeout))
+        self.logger.prn_inf("serial(port=%s, baudrate=%d, read_timeout=%s, write_timeout=%d)"% (self.port, self.baudrate, self.read_timeout, self.write_timeout))
         while time.time() - startTime < self.polling_timeout:
             try:
                 # TIMEOUT: While creating Serial object timeout is delibrately passed as 0. Because blocking in Serial.read
                 # impacts thread and mutliprocess functioning in Python. Hence, instead in self.read() s delay (sleep()) is
                 # inserted to let serial buffer collect data and avoid spinning on non blocking read().
-                self.serial = Serial(self.port, baudrate=self.baudrate, timeout=0)
+                self.serial = Serial(self.port, baudrate=self.baudrate, timeout=0, write_timeout=self.write_timeout)
             except SerialException as e:
                 self.serial = None
-                self.LAST_ERROR = "connection lost, serial.Serial(%s, %d, %d): %s"% (self.port,
+                self.LAST_ERROR = "connection lost, serial.Serial(%s, %d, %d, %d): %s"% (self.port,
                     self.baudrate,
-                    self.timeout,
+                    self.read_timeout,
+                    self.write_timeout,
                     str(e))
                 self.logger.prn_err(str(e))
                 self.logger.prn_err("Retry after 1 sec until %s seconds" % self.polling_timeout)

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -118,11 +118,12 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
                 self.serial.write(payload)
                 if log:
                     self.logger.prn_txd(payload)
-                return payload
+                return True
         except SerialException as e:
             self.serial = None
             self.LAST_ERROR = "connection lost, serial.write(%d bytes): %s"% (len(payload), str(e))
             self.logger.prn_err(str(e))
+        return False
 
     def flush(self):
         if self.serial:

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -114,6 +114,11 @@ def conn_primitive_factory(conn_resource, config, event_queue, logger):
 
 def conn_process(event_queue, dut_event_queue, config):
 
+    def __notify_conn_lost():
+        error_msg = connector.error()
+        connector.finish()
+        event_queue.put(('__notify_conn_lost', error_msg, time()))
+
     logger = HtrunLogger('CONN')
     logger.prn_inf("starting connection process...")
 
@@ -132,8 +137,7 @@ def conn_process(event_queue, dut_event_queue, config):
     # If the connector failed, stop the process now
     if not connector.connected():
         logger.prn_err("Failed to connect to resource")
-        connector.finish()
-        event_queue.put(('__notify_conn_lost', connector.error(), time()))
+        __notify_conn_lost()
         return 0
 
     # Create simple buffer we will use for Key-Value protocol data
@@ -152,11 +156,20 @@ def conn_process(event_queue, dut_event_queue, config):
             logger.prn_inf("resending new preamble '%s' after %0.2f sec"% (sync_uuid, timeout))
         else:
             logger.prn_inf("sending preamble '%s'"% sync_uuid)
-        connector.write_kv('__sync', sync_uuid)
-        return sync_uuid
+        if connector.write_kv('__sync', sync_uuid):
+            return sync_uuid
+        else:
+            return None
 
     # Send simple string to device to 'wake up' greentea-client k-v parser
-    connector.write("mbed" * 10, log=True)
+    wake_up_string = "mbed" * 10
+    written_wake_up_string = connector.write(wake_up_string, log=True)
+
+    # Failed to write 'wake up' string, exit conn_process
+    if written_wake_up_string != wake_up_string:
+        __notify_conn_lost()
+        return 0
+        
 
     # Sync packet management allows us to manipulate the way htrun sends __sync packet(s)
     # With current settings we can force on htrun to send __sync packets in this manner:
@@ -171,25 +184,36 @@ def conn_process(event_queue, dut_event_queue, config):
     if sync_behavior > 0:
         # Sending up to 'n' __sync packets
         logger.prn_inf("sending up to %s __sync packets (specified with --sync=%s)"% (sync_behavior, sync_behavior))
-        sync_uuid_list.append(__send_sync())
-        sync_behavior -= 1
+        sync_uuid = __send_sync()
+
+        if sync_uuid:
+            sync_uuid_list.append(sync_uuid)
+            sync_behavior -= 1
+        else:
+            __notify_conn_lost()
+            return 0
     elif sync_behavior == 0:
         # No __sync packets
         logger.prn_wrn("skipping __sync packet (specified with --sync=%s)"% sync_behavior)
     else:
         # Send __sync until we go reply
         logger.prn_inf("sending multiple __sync packets (specified with --sync=%s)"% sync_behavior)
-        sync_uuid_list.append(__send_sync())
-        sync_behavior -= 1
+
+        sync_uuid = __send_sync()
+
+        if sync_uuid:
+            sync_uuid_list.append(sync_uuid)
+            sync_behavior -= 1
+        else:
+            __notify_conn_lost()
+            return 0
 
     loop_timer = time()
     while True:
 
         # Check if connection is lost to serial
         if not connector.connected():
-            error_msg = connector.error()
-            connector.finish()
-            event_queue.put(('__notify_conn_lost', error_msg, time()))
+            __notify_conn_lost()
             break
 
         # Send data to DUT
@@ -203,7 +227,9 @@ def conn_process(event_queue, dut_event_queue, config):
                 logger.prn_inf("received special even '%s' value='%s', finishing"% (key, value))
                 connector.finish()
                 return 0
-            connector.write_kv(key, value)
+            if not connector.write_kv(key, value):
+                __notify_conn_lost()
+                break
 
         # Since read is done every 0.2 sec, with maximum baud rate we can receive 2304 bytes in one read in worst case.
         data = connector.read(2304)
@@ -241,8 +267,14 @@ def conn_process(event_queue, dut_event_queue, config):
             if sync_behavior != 0:
                 time_to_sync_again = time() - loop_timer
                 if time_to_sync_again > sync_timeout:
-                    sync_uuid_list.append(__send_sync(timeout=time_to_sync_again))
-                    sync_behavior -= 1
-                    loop_timer = time()
+                    sync_uuid = __send_sync(timeout=time_to_sync_again)
+
+                    if sync_uuid:
+                        sync_uuid_list.append(sync_uuid)
+                        sync_behavior -= 1
+                        loop_timer = time()
+                    else:
+                        __notify_conn_lost()
+                        break
 
     return 0

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -162,11 +162,8 @@ def conn_process(event_queue, dut_event_queue, config):
             return None
 
     # Send simple string to device to 'wake up' greentea-client k-v parser
-    wake_up_string = "mbed" * 10
-    written_wake_up_string = connector.write(wake_up_string, log=True)
-
-    # Failed to write 'wake up' string, exit conn_process
-    if written_wake_up_string != wake_up_string:
+    if not connector.write("mbed" * 10, log=True):
+        # Failed to write 'wake up' string, exit conn_process
         __notify_conn_lost()
         return 0
         


### PR DESCRIPTION
Writing to a Serial port works differently on Linux than on Windows. The
pySerial documentation says that the `serial.write()` function will default
to blocking if `write_timeout` is not set. On Linux, this means that the
`serial.write()` blocks forever if the device has not received the data (which
happens in certain cases for different boards). This also occurs in
Windows, however it appears that Windows has a relatively large internal
buffer (~10K) that will cause the serial.write() function to return
immediately if there is still space in the buffer. Only when you send
large amounts of data does the function block.

This PR attempts to standardize the behavior of the host test (and to
prevent indefinite hangs) by introducing a default write timeout of 5
seconds.

It also adds checks throughout the `conn_proxy` to make sure the
call to `write()` actually succeeda. If not, it sets the error and exits.
This commit changes the return value of the `write()` function to `None` if
a write failure occurs. This also affects the function `write_kv()`.

cc @mazimkhan
