### PR TITLE
Add command line switch to specify baud rate

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -58,7 +58,7 @@ HOSTREGISTRY.register_host_test("wait_us_auto", WaitusTest())
 HOSTREGISTRY.register_host_test("dev_null_auto", DevNullTest())
 
 # Set the default baud rate
-DEFAULT_BAUD_RATE = 115200
+DEFAULT_BAUD_RATE = 9600
 
 ###############################################################################
 # Functional interface for test supervisor registry

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -57,6 +57,9 @@ HOSTREGISTRY.register_host_test("default_auto", DefaultAuto())
 HOSTREGISTRY.register_host_test("wait_us_auto", WaitusTest())
 HOSTREGISTRY.register_host_test("dev_null_auto", DevNullTest())
 
+# Set the default baud rate
+DEFAULT_BAUD_RATE = 115200
+
 ###############################################################################
 # Functional interface for test supervisor registry
 ###############################################################################

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -281,6 +281,11 @@ def init_host_test_cli_params():
                       action="store_true",
                       help='Send reset signal to board on specified port (-p PORT) and print serial output. You can combine this with (-r RESET_TYPE) switch')
 
+    parser.add_option('', '--baud-rate',
+                      dest='baud_rate',
+                      help="Baud rate of target, overrides values from mbed-ls, disk/mount point (-d, --disk-path), and serial port -p <port>:<baud rate>",
+                      metavar="BAUD_RATE")
+
     parser.add_option('-v', '--verbose',
                       dest='verbose',
                       default=False,

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from mbed_host_tests import DEFAULT_BAUD_RATE
 from mbed_host_tests.host_tests_conn_proxy.conn_primitive import ConnectorPrimitive
 
 
@@ -28,7 +29,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         self.grm_port = int(config.get('grm_port', 8000))
         self.grm_module = config.get('grm_module', 'unknown')
         self.platform_name = config.get('platform_name', None)
-        self.baudrate = config.get('baudrate', 115200)
+        self.baudrate = config.get('baudrate', DEFAULT_BAUD_RATE)
         self.image_path = config.get('image_path', None)
 
         # Global Resource Mgr tool-kit
@@ -81,7 +82,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
             return False
         return True
 
-    def __remote_connect(self, baudrate=115200, buffer_size=6):
+    def __remote_connect(self, baudrate=DEFAULT_BAUD_RATE, buffer_size=6):
         """! Open remote connection to DUT """
         self.logger.prn_inf("opening connection to platform at baudrate='%s, bufferSize=%d'"% (baudrate, buffer_size))
         try:

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -70,6 +70,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 handle_send_break_cmd(port=options.port,
                     disk=options.disk,
                     reset_type=options.forced_reset_type,
+                    baudrate=options.baud_rate,
                     verbose=options.verbose)
                 sys.exit(0)
 

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -19,6 +19,7 @@ Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
 
 import json
 from time import sleep
+from mbed_host_tests import DEFAULT_BAUD_RATE
 import mbed_host_tests.host_tests_plugins as ht_plugins
 
 
@@ -44,7 +45,7 @@ class Mbed:
         self.pooling_timeout = self.options.pooling_timeout
 
         # Serial port settings
-        self.serial_baud = 115200
+        self.serial_baud = DEFAULT_BAUD_RATE
         self.serial_timeout = 1
 
         # Users can use command to pass port speeds together with port name. E.g. COM4:115200:1
@@ -60,6 +61,7 @@ class Mbed:
             self.serial_baud = int(port_config[1])
             self.serial_timeout = float(port_config[2])
 
+        # Overriding baud rate value with command line specified value
         self.serial_baud = self.options.baud_rate if self.options.baud_rate else self.serial_baud
 
         # Test configuration in JSON format

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -60,6 +60,8 @@ class Mbed:
             self.serial_baud = int(port_config[1])
             self.serial_timeout = float(port_config[2])
 
+        self.serial_baud = self.options.baud_rate if self.options.baud_rate else self.serial_baud
+
         # Test configuration in JSON format
         self.test_cfg = None
         if self.options.json_test_configuration is not None:

--- a/mbed_host_tests/host_tests_toolbox/host_functional.py
+++ b/mbed_host_tests/host_tests_toolbox/host_functional.py
@@ -84,7 +84,7 @@ def reset_dev(port=None,
 def handle_send_break_cmd(port,
                           disk,
                           reset_type=None,
-                          baudrate=115200,
+                          baudrate=None,
                           timeout=1,
                           verbose=False):
     """! Resets platforms and prints serial port output
@@ -97,12 +97,15 @@ def handle_send_break_cmd(port,
     if len(port_config) == 2:
         # -p COM4:115200
         port = port_config[0]
-        baudrate = int(port_config[1])
+        baudrate = int(port_config[1]) if not baudrate else baudrate
     elif len(port_config) == 3:
         # -p COM4:115200:0.5
         port = port_config[0]
-        baudrate = int(port_config[1])
+        baudrate = int(port_config[1]) if not baudrate else baudrate
         timeout = float(port_config[2])
+
+    if not baudrate:
+        baudrate = 115200
 
     if verbose:
         print "mbedhtrun: serial port configuration: %s:%s:%s"% (port, str(baudrate), str(timeout))

--- a/mbed_host_tests/host_tests_toolbox/host_functional.py
+++ b/mbed_host_tests/host_tests_toolbox/host_functional.py
@@ -21,7 +21,7 @@ import sys
 import json
 from time import sleep
 from serial import Serial, SerialException
-from mbed_host_tests import host_tests_plugins
+from mbed_host_tests import host_tests_plugins, DEFAULT_BAUD_RATE
 
 
 def flash_dev(disk=None,
@@ -51,7 +51,7 @@ def reset_dev(port=None,
               reset_type='default',
               reset_timeout=1,
               serial_port=None,
-              baudrate=115200,
+              baudrate=DEFAULT_BAUD_RATE,
               timeout=1,
               verbose=False):
     """! Reset device using pythonic interface
@@ -104,8 +104,9 @@ def handle_send_break_cmd(port,
         baudrate = int(port_config[1]) if not baudrate else baudrate
         timeout = float(port_config[2])
 
+    # Use default baud rate value if not set
     if not baudrate:
-        baudrate = 115200
+        baudrate = DEFAULT_BAUD_RATE
 
     if verbose:
         print "mbedhtrun: serial port configuration: %s:%s:%s"% (port, str(baudrate), str(timeout))


### PR DESCRIPTION
# Changes
* Add command line switch `--baud-rate` to specify the baud rate of the target
* Switch overrides value from target ID, mbed-ls, `-d,--disk-path` disk/mount point, `-p <port>:<baud rate>` for serial port

# Implements
* This pull request implements part of #87 