### PR TITLE
Add idle timeout for coverage

### DIFF
--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -215,6 +215,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         p = start_conn_process()
 
         start_time = time()
+
         try:
             consume_preamble_events = True
 
@@ -289,6 +290,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                     elif key.startswith('__'):
                         # Consume other system level events
                         pass
+                    else:
+                        self.logger.prn_err("orphan event in preamble phase: {{%s;%s}}, timestamp=%f"% (key, str(value), timestamp))
                 else:
                     # If coverage detected switch to idle loop
                     if key == '__coverage_start':
@@ -304,7 +307,6 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                         # or if value is None, value will be retrieved from HostTest.result() method
                         self.logger.prn_inf("%s(%s)"% (key, str(value)))
                         result = value
-                        break
                     elif key == '__reset_dut':
                         # Disconnect to avoid connection lost event
                         dut_event_queue.put(('__host_test_finished', True, time()))


### PR DESCRIPTION
# Changes
* Detect when coverage is being output, and switch to an idle timeout, where the timer is reset whenever a new coverage packet is received.
* The idle timeout with timeout when a key value pair hasn't been received within the idle timeout duration, which by default is 10 seconds.
* Idle timeout saves the remaining time in the original timeout, and when a key that is not coverage is received, that timeout is restored.
* This is needed as coverage takes far longer to receive from the target than the timeouts that are set by the test, which causes most of the coverage data to be missed, and most of the tests to fail because of timeouts.