### PR TITLE
Increasing initial timeout to 1 minute

### DIFF
--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -116,7 +116,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         @return Return self.TestResults.RESULT_* enum
         """
         result = None
-        timeout_duration = 10       # Default test case timeout
+        timeout_duration = 60       # Default test case timeout
         event_queue = Queue()       # Events from DUT to host
         dut_event_queue = Queue()   # Events from host to DUT {k;v}
 


### PR DESCRIPTION
If a system is under heavy load, it can sometimes take longer than 10
seconds for the conn_process to start. This commit increases that timeout
to improve reliability on these systems.

This behavior can be seen in the following log from CI:

```
[1473742292.89][HTST][INF] host test executor ver. 1.1.0
[1473742292.89][HTST][INF] copy image onto target...
[1473742292.89][COPY][INF] Waiting up to 60 sec for '110100004420312033504139333031313431303497969903' mount point (current is 'L:')...
        1 file(s) copied.
[1473742305.41][HTST][INF] starting host test process...
[1473742315.41][HTST][INF] test suite run finished after 10.00 sec...
[1473742330.12][CONN][INF] starting connection process...
[1473742330.12][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1473742330.12][CONN][INF] initializing serial port listener... 
[1473742330.12][SERI][INF] serial(port=COM13, baudrate=9600, timeout=0, write_timeout=5)
[1473742330.12][PLGN][INF] Waiting up to 60 sec for '110100004420312033504139333031313431303497969903' serial port (current is 'COM13')...
[1473742330.18][SERI][INF] reset device using 'default' plugin...
[1473742330.43][SERI][INF] waiting 1.00 sec after reset
[1473742331.43][SERI][INF] wait for it...
[1473742331.43][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1473742331.43][CONN][INF] sending up to 2 __sync packets (specified with --sync=2)
[1473742331.43][CONN][INF] sending preamble '4abff833-32f6-4228-8073-b62f5e5539b2'
[1473742331.43][SERI][TXD] {{__sync;4abff833-32f6-4228-8073-b62f5e5539b2}}
[1473742331.43][CONN][INF] received special even '__host_test_finished' value='True', finishing
[1473742331.45][HTST][INF] CONN exited with code: 0
[1473742331.45][HTST][INF] Some events in queue
[1473742331.45][HTST][INF] stopped consuming events
[1473742331.45][HTST][INF] host test result(): None
[1473742331.45][HTST][WRN] missing __exit event from DUT
[1473742331.45][HTST][WRN] missing __exit_event_queue event from host test
[1473742331.45][HTST][ERR] missing __exit_event_queue event from host test and no result from host test, timeout...
[1473742331.45][HTST][INF] calling blocking teardown()
[1473742331.45][HTST][INF] teardown() finished
[1473742331.45][HTST][INF] {{result;timeout}}
```

You can see between the following lines:

```
[1473742305.41][HTST][INF] starting host test process...
[1473742315.41][HTST][INF] test suite run finished after 10.00 sec...
[1473742330.12][CONN][INF] starting connection process...
```

that it took 25 seconds to start the connection process thread. If the system is under heavy load, this may be reasonable, especially if `htrun` is always waiting for device to remount.

Please review @mazimkhan
FYI @adbridge 