### PR TITLE
Fixed tight loop while checking event_queue

### DIFF
--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -182,126 +182,125 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             consume_preamble_events = True
             while (time() - start_time) < timeout_duration:
                 # Handle default events like timeout, host_test_name, ...
-                if not event_queue.empty():
-                    try:
-                        (key, value, timestamp) = event_queue.get(timeout=1)
-                    except QueueEmpty:
-                        continue
+                try:
+                    (key, value, timestamp) = event_queue.get(timeout=1)
+                except QueueEmpty:
+                    continue
 
-                    if consume_preamble_events:
-                        if key == '__timeout':
-                            # Override default timeout for this event queue
-                            start_time = time()
-                            timeout_duration = int(value) # New timeout
-                            self.logger.prn_inf("setting timeout to: %d sec"% int(value))
-                        elif key == '__version':
-                            self.client_version = value
-                            self.logger.prn_inf("DUT greentea-client version: " + self.client_version)
-                        elif key == '__host_test_name':
-                            # Load dynamically requested host test
-                            self.test_supervisor = get_host_test(value)
+                if consume_preamble_events:
+                    if key == '__timeout':
+                        # Override default timeout for this event queue
+                        start_time = time()
+                        timeout_duration = int(value) # New timeout
+                        self.logger.prn_inf("setting timeout to: %d sec"% int(value))
+                    elif key == '__version':
+                        self.client_version = value
+                        self.logger.prn_inf("DUT greentea-client version: " + self.client_version)
+                    elif key == '__host_test_name':
+                        # Load dynamically requested host test
+                        self.test_supervisor = get_host_test(value)
 
-                            # Check if host test object loaded is actually host test class
-                            # derived from 'mbed_host_tests.BaseHostTest()'
-                            # Additionaly if host test class implements custom ctor it should
-                            # call BaseHostTest().__Init__()
-                            if self.test_supervisor and self.is_host_test_obj_compatible(self.test_supervisor):
-                                # Pass communication queues and setup() host test
-                                self.test_supervisor.setup_communication(event_queue, dut_event_queue)
-                                try:
-                                    # After setup() user should already register all callbacks
-                                    self.test_supervisor.setup()
-                                except (TypeError, ValueError):
-                                    # setup() can throw in normal circumstances TypeError and ValueError
-                                    self.logger.prn_err("host test setup() failed, reason:")
-                                    self.logger.prn_inf("==== Traceback start ====")
-                                    for line in traceback.format_exc().splitlines():
-                                        print line
-                                    self.logger.prn_inf("==== Traceback end ====")
-                                    result = self.RESULT_ERROR
-                                    event_queue.put(('__exit_event_queue', 0, time()))
-
-                                self.logger.prn_inf("host test setup() call...")
-                                if self.test_supervisor.get_callbacks():
-                                    callbacks.update(self.test_supervisor.get_callbacks())
-                                    self.logger.prn_inf("CALLBACKs updated")
-                                else:
-                                    self.logger.prn_wrn("no CALLBACKs specified by host test")
-                                self.logger.prn_inf("host test detected: %s"% value)
-                            else:
-                                self.logger.prn_err("host test not detected: %s"% value)
+                        # Check if host test object loaded is actually host test class
+                        # derived from 'mbed_host_tests.BaseHostTest()'
+                        # Additionaly if host test class implements custom ctor it should
+                        # call BaseHostTest().__Init__()
+                        if self.test_supervisor and self.is_host_test_obj_compatible(self.test_supervisor):
+                            # Pass communication queues and setup() host test
+                            self.test_supervisor.setup_communication(event_queue, dut_event_queue)
+                            try:
+                                # After setup() user should already register all callbacks
+                                self.test_supervisor.setup()
+                            except (TypeError, ValueError):
+                                # setup() can throw in normal circumstances TypeError and ValueError
+                                self.logger.prn_err("host test setup() failed, reason:")
+                                self.logger.prn_inf("==== Traceback start ====")
+                                for line in traceback.format_exc().splitlines():
+                                    print line
+                                self.logger.prn_inf("==== Traceback end ====")
                                 result = self.RESULT_ERROR
                                 event_queue.put(('__exit_event_queue', 0, time()))
 
-                            consume_preamble_events = False
-                        elif key == '__sync':
-                            # This is DUT-Host Test handshake event
-                            self.logger.prn_inf("sync KV found, uuid=%s, timestamp=%f"% (str(value), timestamp))
-                        elif key == '__notify_conn_lost':
-                            # This event is sent by conn_process, DUT connection was lost
-                            self.logger.prn_err(value)
-                            self.logger.prn_wrn("stopped to consume events due to %s event"% key)
-                            callbacks_consume = False
-                            result = self.RESULT_IO_SERIAL
-                            event_queue.put(('__exit_event_queue', 0, time()))
-                        elif key == '__exit_event_queue':
-                            # This event is sent by the host test indicating no more events expected
-                            self.logger.prn_inf("%s received"% (key))
-                            callbacks__exit_event_queue = True
-                            break
-                        elif key.startswith('__'):
-                            # Consume other system level events
-                            pass
-                        else:
-                            self.logger.prn_err("orphan event in preamble phase: {{%s;%s}}, timestamp=%f"% (key, str(value), timestamp))
-                    else:
-                        if key == '__notify_complete':
-                            # This event is sent by Host Test, test result is in value
-                            # or if value is None, value will be retrieved from HostTest.result() method
-                            self.logger.prn_inf("%s(%s)"% (key, str(value)))
-                            result = value
-                        elif key == '__reset_dut':
-                            # Disconnect to avoid connection lost event
-                            dut_event_queue.put(('__host_test_finished', True, time()))
-                            p.join()
-
-                            if value == DefaultTestSelector.RESET_TYPE_SW_RST:
-                                self.logger.prn_inf("Performing software reset.")
-                                # Just disconnecting and re-connecting comm process will soft reset DUT
-                            elif value == DefaultTestSelector.RESET_TYPE_HW_RST:
-                                self.logger.prn_inf("Performing hard reset.")
-                                # request hardware reset
-                                self.mbed.hw_reset()
+                            self.logger.prn_inf("host test setup() call...")
+                            if self.test_supervisor.get_callbacks():
+                                callbacks.update(self.test_supervisor.get_callbacks())
+                                self.logger.prn_inf("CALLBACKs updated")
                             else:
-                                self.logger.prn_err("Invalid reset type (%s). Supported types [%s]." %
-                                                    (value, ", ".join([DefaultTestSelector.RESET_TYPE_HW_RST,
-                                                                       DefaultTestSelector.RESET_TYPE_SW_RST])))
-                                self.logger.prn_inf("Software reset will be performed.")
-
-                            # connect to the device
-                            p = start_conn_process()
-                        elif key == '__notify_conn_lost':
-                            # This event is sent by conn_process, DUT connection was lost
-                            self.logger.prn_err(value)
-                            self.logger.prn_wrn("stopped to consume events due to %s event"% key)
-                            callbacks_consume = False
-                            result = self.RESULT_IO_SERIAL
-                            event_queue.put(('__exit_event_queue', 0, time()))
-                        elif key == '__exit':
-                            # This event is sent by DUT, test suite exited
-                            self.logger.prn_inf("%s(%s)"% (key, str(value)))
-                            callbacks__exit = True
-                            event_queue.put(('__exit_event_queue', 0, time()))
-                        elif key == '__exit_event_queue':
-                            # This event is sent by the host test indicating no more events expected
-                            self.logger.prn_inf("%s received"% (key))
-                            callbacks__exit_event_queue = True
-                            break
-                        elif key in callbacks:
-                            # Handle callback
-                            callbacks[key](key, value, timestamp)
+                                self.logger.prn_wrn("no CALLBACKs specified by host test")
+                            self.logger.prn_inf("host test detected: %s"% value)
                         else:
-                            self.logger.prn_err("orphan event in main phase: {{%s;%s}}, timestamp=%f"% (key, str(value), timestamp))
+                            self.logger.prn_err("host test not detected: %s"% value)
+                            result = self.RESULT_ERROR
+                            event_queue.put(('__exit_event_queue', 0, time()))
+
+                        consume_preamble_events = False
+                    elif key == '__sync':
+                        # This is DUT-Host Test handshake event
+                        self.logger.prn_inf("sync KV found, uuid=%s, timestamp=%f"% (str(value), timestamp))
+                    elif key == '__notify_conn_lost':
+                        # This event is sent by conn_process, DUT connection was lost
+                        self.logger.prn_err(value)
+                        self.logger.prn_wrn("stopped to consume events due to %s event"% key)
+                        callbacks_consume = False
+                        result = self.RESULT_IO_SERIAL
+                        event_queue.put(('__exit_event_queue', 0, time()))
+                    elif key == '__exit_event_queue':
+                        # This event is sent by the host test indicating no more events expected
+                        self.logger.prn_inf("%s received"% (key))
+                        callbacks__exit_event_queue = True
+                        break
+                    elif key.startswith('__'):
+                        # Consume other system level events
+                        pass
+                    else:
+                        self.logger.prn_err("orphan event in preamble phase: {{%s;%s}}, timestamp=%f"% (key, str(value), timestamp))
+                else:
+                    if key == '__notify_complete':
+                        # This event is sent by Host Test, test result is in value
+                        # or if value is None, value will be retrieved from HostTest.result() method
+                        self.logger.prn_inf("%s(%s)"% (key, str(value)))
+                        result = value
+                    elif key == '__reset_dut':
+                        # Disconnect to avoid connection lost event
+                        dut_event_queue.put(('__host_test_finished', True, time()))
+                        p.join()
+
+                        if value == DefaultTestSelector.RESET_TYPE_SW_RST:
+                            self.logger.prn_inf("Performing software reset.")
+                            # Just disconnecting and re-connecting comm process will soft reset DUT
+                        elif value == DefaultTestSelector.RESET_TYPE_HW_RST:
+                            self.logger.prn_inf("Performing hard reset.")
+                            # request hardware reset
+                            self.mbed.hw_reset()
+                        else:
+                            self.logger.prn_err("Invalid reset type (%s). Supported types [%s]." %
+                                                (value, ", ".join([DefaultTestSelector.RESET_TYPE_HW_RST,
+                                                                   DefaultTestSelector.RESET_TYPE_SW_RST])))
+                            self.logger.prn_inf("Software reset will be performed.")
+
+                        # connect to the device
+                        p = start_conn_process()
+                    elif key == '__notify_conn_lost':
+                        # This event is sent by conn_process, DUT connection was lost
+                        self.logger.prn_err(value)
+                        self.logger.prn_wrn("stopped to consume events due to %s event"% key)
+                        callbacks_consume = False
+                        result = self.RESULT_IO_SERIAL
+                        event_queue.put(('__exit_event_queue', 0, time()))
+                    elif key == '__exit':
+                        # This event is sent by DUT, test suite exited
+                        self.logger.prn_inf("%s(%s)"% (key, str(value)))
+                        callbacks__exit = True
+                        event_queue.put(('__exit_event_queue', 0, time()))
+                    elif key == '__exit_event_queue':
+                        # This event is sent by the host test indicating no more events expected
+                        self.logger.prn_inf("%s received"% (key))
+                        callbacks__exit_event_queue = True
+                        break
+                    elif key in callbacks:
+                        # Handle callback
+                        callbacks[key](key, value, timestamp)
+                    else:
+                        self.logger.prn_err("orphan event in main phase: {{%s;%s}}, timestamp=%f"% (key, str(value), timestamp))
         except Exception:
             self.logger.prn_err("something went wrong in event main loop!")
             self.logger.prn_inf("==== Traceback start ====")


### PR DESCRIPTION
In actual code below there is a tight loop:
```
            while (time() - start_time) < timeout_duration:
                # Handle default events like timeout, host_test_name, ...
                self.logger.prn_inf("Tight loop")
                if not event_queue.empty():
                    try:
                        (key, value, timestamp) = event_queue.get(timeout=1)
                    except QueueEmpty:
                        continue    
```

```self.logger.prn_inf("Tight loop")``` line is added to demonstrate this. Try this and you can observe how much it is printed.
It can have a vicious impact on slower platforms like RPi where starting conn process takes time hence more spinning on checking ```queue.empty()```.

Check ```if not event_queue.empty():``` causes the tight loop as it evaluates to False until there is data in the queue. This check is redundant as check element in the queue inside a ```try``` block and catch ```QueueEmpty``` exception and return to the loop. ```try``` block is better as ```event_queue.get(timeout=1)``` waits ```timeout``` seconds before returning and does not cause uncontrolled spinning.