### PR TITLE
Fixed performance issue due to spinning on non blocking Serial.read()

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -29,7 +29,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         ConnectorPrimitive.__init__(self, name)
         self.port = port
         self.baudrate = int(baudrate)
-        self.timeout = 0.2  # 200 milli sec
+        self.timeout = 0.01  # 10 milli sec
         self.config = config
         self.target_id = self.config.get('target_id', None)
         self.serial_pooling = config.get('serial_pooling', 60)
@@ -57,7 +57,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
             self.serial = Serial(self.port, baudrate=self.baudrate, timeout=0)
         except SerialException as e:
             self.serial = None
-            self.LAST_ERROR = "connection lost, serial.Serial(%s. %d, %d): %s"% (self.port,
+            self.LAST_ERROR = "connection lost, serial.Serial(%s, %d, %d): %s"% (self.port,
                 self.baudrate,
                 self.timeout,
                 str(e))

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -202,7 +202,8 @@ def conn_process(event_queue, dut_event_queue, config):
                 return 0
             connector.write_kv(key, value)
 
-        data = connector.read(2048)
+        # Since read is done every 0.2 sec, with maximum baud rate we can receive 2304 bytes in one read in worst case.
+        data = connector.read(2304)
         if data:
             # Stream data stream KV parsing
             print_lines = kv_buffer.append(data)

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -39,6 +39,7 @@ class KiViBufferWalker():
         lines = self.buff.split('\n')
         self.buff = lines[-1]   # remaining
         lines.pop(-1)
+        # List of line or strings that did not match K,V pair.
         discarded = []
 
         for line in lines:
@@ -54,6 +55,7 @@ class KiViBufferWalker():
                 if len(before) > 0:
                     discarded.append(before)
                 if len(after) > 0:
+                    # not a K,V pair part
                     discarded.append(after)
             else:
                 # not a K,V pair

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -194,23 +194,22 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
             # Start idle timeout loop looking for other events
             while (time() - start_time) < coverage_idle_timeout:
-                if not event_queue.empty():
-                    try:
-                        (key, value, timestamp) = event_queue.get(timeout=1)
-                    except QueueEmpty:
-                        continue
+                try:
+                    (key, value, timestamp) = event_queue.get(timeout=1)
+                except QueueEmpty:
+                    continue
 
-                    # If coverage detected use idle loop
-                    # Prevent breaking idle loop for __rxd_line (occurs between keys)
-                    if key == '__coverage_start' or key == '__rxd_line':
-                        start_time = time()
+                # If coverage detected use idle loop
+                # Prevent breaking idle loop for __rxd_line (occurs between keys)
+                if key == '__coverage_start' or key == '__rxd_line':
+                    start_time = time()
 
-                        # Perform callback
-                        callbacks[key](key, value, timestamp)
-                        continue
+                    # Perform callback
+                    callbacks[key](key, value, timestamp)
+                    continue
 
-                    elapsed_time = time() - original_start_time
-                    return elapsed_time, (key, value, timestamp)
+                elapsed_time = time() - original_start_time
+                return elapsed_time, (key, value, timestamp)
 
         p = start_conn_process()
 


### PR DESCRIPTION
Three changes:
- Added a delay in call to ```Serial.read()``` as ```timeout``` is set to 0 making ```read()``` non blocking. This makes connection process loop to keep spinning on ```read()``` when there is no data resulting in high CPU usage. Serial timeout is not used as blocking ```read``` call impacts thread switching in python causing undefined behaviour. 
- Avoiding K,V pair lines/ data from printing as ```printf``` prints (```__rxd_line```) from the target.
- Removed use of ```event_queue.empty()``` from ```process_code_coverage()``` as it causes spinning in the loop when there is not element in queue.