### PR TITLE
Removes connection process from initial timeout section

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -229,6 +229,13 @@ def init_host_test_cli_params():
                       type="float",
                       help="When forcing a reset using option -r you can set up after reset idle delay in seconds (Default is 1 second)")
 
+    parser.add_option("--process-start-timeout",
+                      dest="process_start_timeout",
+                      default=60,
+                      metavar="NUMBER",
+                      type="float",
+                      help="This sets the maximum time in seconds to wait for an internal process to start. This mostly only affects machines under heavy load (Default is 60 seconds)")
+
     parser.add_option("-e", "--enum-host-tests",
                       dest="enum_host_tests",
                       help="Define directory with local host tests")

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -128,6 +128,10 @@ def conn_process(event_queue, dut_event_queue, config):
     logger = HtrunLogger('CONN')
     logger.prn_inf("starting connection process...")
 
+    # Send connection process start event to host process
+    # NOTE: Do not send any other Key-Value pairs before this!
+    event_queue.put(('__conn_process_start', 1, time()))
+
     # Configuration of conn_opriocess behaviour
     sync_behavior = int(config.get('sync_behavior', 1))
     sync_timeout = config.get('sync_timeout', 1.0)

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -213,6 +213,22 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         p = start_conn_process()
 
+        conn_process_started = False
+        try:
+            (key, value, timestamp) = event_queue.get(timeout=self.options.process_start_timeout)
+
+            if key == '__conn_process_start':
+                conn_process_started = True
+            else:
+                self.logger.prn_err("First expected event was '__conn_process_start', received '%s' instead"% key)
+
+        except QueueEmpty:
+            self.logger.prn_err("Conn process failed to start in %f sec"% self.options.process_start_timeout)
+
+        if not conn_process_started:
+            p.terminate()
+            return self.RESULT_TIMEOUT
+
         start_time = time()
 
         try:


### PR DESCRIPTION
This PR is a continuation of the work done in #126 

The connection process can sometimes take a lot longer to begin if the system is under heavy load. This allows for a configurable timeout for the connection process to start up, defaulting to 60 seconds. If the connection process fails to start, it returns a result of "TIMEOUT".

Here is what the output looks like if the connection process times out now (NOTE: I set the timeout very low here to force a timeout):

```
$ mbedhtrun --process-start-timeout=0.01 -m K64F -p COM9:9600 -f "BUILD/tests/K64F/GCC_ARM/TESTS/mbedmicro-rtos-mbed/queue/queue.bin" -d J: -C 4 -c shell -t 0240000025354e450025400d47d00046bb91000097969900 -e "TESTS\host_tests"
[1476390997.58][HTST][INF] host test executor ver. 1.1.3
[1476390997.58][HTST][INF] copy image onto target...
[1476390997.58][COPY][INF] Waiting up to 60 sec for '0240000025354e450025400d47d00046bb91000097969900' mount point (current is 'J:')...
        1 file(s) copied.
[1476391006.68][HTST][INF] starting host test process...
[1476391006.70][HTST][ERR] Conn process failed to start in 0.010000 sec
[1476391006.70][HTST][INF] test suite run finished after 0.00 sec...
[1476391006.71][HTST][INF] CONN exited with code: -15
[1476391006.71][HTST][INF] No events in queue
[1476391006.71][HTST][INF] stopped consuming events
[1476391006.71][HTST][INF] host test result(): None
[1476391006.71][HTST][WRN] missing __exit event from DUT
[1476391006.71][HTST][WRN] missing __exit_event_queue event from host test
[1476391006.71][HTST][ERR] missing __exit_event_queue event from host test and no result from host test, timeout...
[1476391006.71][HTST][INF] calling blocking teardown()
[1476391006.72][HTST][INF] teardown() finished
[1476391006.72][HTST][INF] {{result;timeout}}

$echo %errorlevel%
5
```

Please review @mazimkhan 