### PR TITLE
Check if mbed disconnects and connects back after flashing and before testing

### DIFF
--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -149,6 +149,7 @@ class Mbed:
                     if file.lower() == 'assert.txt':
                         assert_file = os.path.join(mbed_drive, file)
             if assert_file:
+                print "MBED: Removing %s" % assert_file
                 os.remove(assert_file)
                 time.sleep(1)
 

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -112,6 +112,7 @@ class Mbed:
                     time.sleep(1)
                     mbed_htm_fd.read(1)
                     mbed_htm_fd.seek(0)
+                print 'MBED: Board did not disconnect!'
             except IOError, e:
                 print 'MBED: Board disconnected @%s' % time.ctime()
 

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -121,29 +121,36 @@ class Mbed:
         sleep(self.program_cycle_s)
 
         if check_remount:
-            mbed = None
             for i in range (60):
                 mbeds = mbed_lstools.create().list_mbeds_by_targetid()
                 if self.target_id in mbeds and \
                         mbeds[self.target_id]['mount_point'] and \
                         mbeds[self.target_id]['serial_port']:
                     print "MBED: Board connected @%s" % time.ctime()
-                    mbed = mbeds[self.target_id]
                     break
                 time.sleep(1)
-            # Check for *.txt files in mbed drive
-            if mbed:
-                mbed_drive = mbed['mount_point']
-                files = os.listdir(mbed_drive)
-                print "MBED: Files in mbed drive %s:" % mbed_drive
-                print "\n".join(files)
-                for file in files:
-                    path = os.path.join(mbed_drive, file)
-                    if os.path.splitext(path)[1].lower() == '.txt':
-                        print "MBED: File %s" % path
-                        print "MBED: ============="
-                        with open(path, 'r') as f:
-                            print f.read(1000)
+
+        # Check for *.txt files in mbed drive
+        mbeds = mbed_lstools.create().list_mbeds_by_targetid()
+        if self.target_id in mbeds:
+            mbed = mbeds[self.target_id]
+            mbed_drive = mbed['mount_point']
+            files = os.listdir(mbed_drive)
+            print "MBED: Files in mbed drive %s:" % mbed_drive
+            print "\n".join(files)
+            assert_file = None
+            for file in files:
+                path = os.path.join(mbed_drive, file)
+                if os.path.splitext(path)[1].lower() == '.txt':
+                    print "MBED: File %s" % path
+                    print "MBED: ============="
+                    with open(path, 'r') as f:
+                        print f.read(1000)
+                    if file.lower() == 'assert.txt':
+                        assert_file = os.path.join(mbed_drive, file)
+            if assert_file:
+                os.remove(assert_file)
+                time.sleep(1)
 
         return result
 

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -121,14 +121,30 @@ class Mbed:
         sleep(self.program_cycle_s)
 
         if check_remount:
+            mbed = None
             for i in range (60):
                 mbeds = mbed_lstools.create().list_mbeds_by_targetid()
                 if self.target_id in mbeds and \
                         mbeds[self.target_id]['mount_point'] and \
                         mbeds[self.target_id]['serial_port']:
                     print "MBED: Board connected @%s" % time.ctime()
+                    mbed = mbeds[self.target_id]
                     break
                 time.sleep(1)
+            # Check for *.txt files in mbed drive
+            if mbed:
+                mbed_drive = mbed['mount_point']
+                files = os.listdir(mbed_drive)
+                print "MBED: Files in mbed drive %s:" % mbed_drive
+                print "\n".join(files)
+                for file in files:
+                    path = os.path.join(mbed_drive, file)
+                    if os.path.splitext(path)[1].lower() == '.txt':
+                        print "MBED: File %s" % path
+                        print "MBED: ============="
+                        with open(path, 'r') as f:
+                            print f.read(1000)
+
         return result
 
     def copy_image_raw(self, image_path=None, disk=None, copy_method=None, port=None):

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -110,6 +110,8 @@ class Mbed:
             try:
                 for i in range (60):
                     time.sleep(1)
+                    import subprocess
+                    subprocess.call(['sync'])
                     mbed_htm_fd.read(1)
                     mbed_htm_fd.seek(0)
                 print 'MBED: Board did not disconnect!'


### PR DESCRIPTION
It is observed in CI that opening serial port occasionally fails after flashing with error:

```
[1476968928.23][SERI][ERR] Cannot configure port, something went wrong. Original message: WindowsError(31, 'A device attached to the system is not functioning.')
```

This is suspected to be because copy command has finished and `htrun` has proceeded to opening the serial port. But board is still being programmed or is being remounted. Hence it is required we check that board is remounted after flashing and before starting testing.

Changes here check that the board is disconnected and connected back. This is done by obtaining a file handle in mbed mount point and waiting until it gets invalid indicating disconnect. Then waiting for mbed to connect back.

mbed-ls polling can't be used because it checks mbed at the instance it is run. Hence can't determine remount if mbed goes and comes back too quickly.  

This check for remount is only to enhance robustness. If remount does not happen no exception is raised.
