### PR TITLE
Add Sara-N host test hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
   * [ ```htrun``` new log format:](#-htrun-new-log-format)
     * [Log example](#log-example)
 * [End-to-end examples](#end-to-end-examples)
+* [Plugins](#plugins)
+  * [SARA NBIOT EVK](#sara-nbiot-evk)
 
 # Quickstart
 
@@ -1009,3 +1011,10 @@ Here you can find references to modules and repositories contain examples of tes
 * ```minar``` module contains [test cases](https://github.com/ARMmbed/minar/tree/master/test) written without ```utest```. Note: ```utest``` may use ```minar``` for callback scheduling and can't be use to test ```minar``` itself.
 * ```mbed-drivers``` module contains [test cases](https://github.com/ARMmbed/mbed-drivers/tree/master/test) written with and without ```utest``` harness. Currently all ```mbed-drivers``` tests are using [build-in to ```htrun``` host tests](https://github.com/ARMmbed/htrun/tree/master/mbed_host_tests/host_tests).
 * And finally ```sockets``` module contains [test cases](https://github.com/ARMmbed/sockets/tree/master/test) with [custom host tests](https://github.com/ARMmbed/sockets/tree/master/test/host_tests).
+
+# Plugins
+
+In order to work with platforms for which the hardware is still under development, and hence may not have an mbed interface chip, some "hook" files are required.  Operation with these platforms is a matter for the platform development teams involved and is not, in general, supported by ARM.
+
+## SARA NBIOT EVK
+The SARA NBIOT EVK board must be connected to a Windows PC using a Segger JLink box, which is used for downloading code and resetting the board. The USB port on the EVK must also be connected to the same PC.  To make use of these hooks you will also require access to some proprietary tools that can be requested from u-blox.

--- a/mbed_host_tests/host_tests_plugins/__init__.py
+++ b/mbed_host_tests/host_tests_plugins/__init__.py
@@ -37,6 +37,8 @@ import module_copy_silabs
 import module_reset_silabs
 import module_copy_stlink
 import module_reset_stlink
+import module_copy_ublox
+import module_reset_ublox
 #import module_copy_jn51xx
 #import module_reset_jn51xx
 
@@ -58,6 +60,8 @@ HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_silabs.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_stlink.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_stlink.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_power_cycle_mbed.load_plugin())
+HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_ublox.load_plugin())
+HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_ublox.load_plugin())
 #HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_jn51xx.load_plugin())
 #HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_jn51xx.load_plugin())
 

--- a/mbed_host_tests/host_tests_plugins/module_copy_ublox.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_ublox.py
@@ -1,0 +1,83 @@
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
+"""
+
+import os
+from host_test_plugins import HostTestPluginBase
+
+
+class HostTestPluginCopyMethod_ublox(HostTestPluginBase):
+
+    # Plugin interface
+    name = 'HostTestPluginCopyMethod_ublox'
+    type = 'CopyMethod'
+    capabilities = ['ublox']
+    required_parameters = ['image_path']
+
+    def is_os_supported(self, os_name=None):
+        """! In this implementation this plugin only is supporeted under Windows machines
+        """
+        # If no OS name provided use host OS name
+        if not os_name:
+            os_name = self.mbed_os_support()
+
+        # This plugin only works on Windows
+        if os_name and os_name.startswith('Windows'):
+            return True
+        return False
+
+    def setup(self, *args, **kwargs):
+        """! Configure plugin, this function should be called before plugin execute() method is used.
+        """
+        self.FLASH_ERASE = 'FlashErase.exe'
+        return True
+
+    def execute(self, capability, *args, **kwargs):
+        """! Executes capability by name
+
+        @param capability Capability name
+        @param args Additional arguments
+        @param kwargs Additional arguments
+
+        @details Each capability e.g. may directly just call some command line program or execute building pythonic function
+
+        @return Capability call return value
+        """
+        result = False
+        if self.check_parameters(capability, *args, **kwargs) is True:
+            image_path = os.path.normpath(kwargs['image_path'])
+            if capability == 'ublox':
+                # Example:
+                # FLASH_ERASE -c 2 -s 0xD7000 -l 0x20000 -f "binary_file.bin"
+                cmd = [self.FLASH_ERASE,
+                       '-c',
+                       'A',
+                       '-s',
+                       '0xD7000',
+                       '-l',
+                       '0x20000',
+                       '-f', image_path
+                       ]
+                result = self.run_command(cmd)
+        return result
+
+
+def load_plugin():
+    """ Returns plugin available in this module
+    """
+    return HostTestPluginCopyMethod_ublox()

--- a/mbed_host_tests/host_tests_plugins/module_reset_ublox.py
+++ b/mbed_host_tests/host_tests_plugins/module_reset_ublox.py
@@ -1,0 +1,77 @@
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
+"""
+
+from host_test_plugins import HostTestPluginBase
+
+
+class HostTestPluginResetMethod_ublox(HostTestPluginBase):
+
+    # Plugin interface
+    name = 'HostTestPluginResetMethod_ublox'
+    type = 'ResetMethod'
+    capabilities = ['ublox']
+    required_parameters = []
+    stable = False
+
+    def is_os_supported(self, os_name=None):
+        """! In this implementation this plugin only is supporeted under Windows machines
+        """
+        # If no OS name provided use host OS name
+        if not os_name:
+            os_name = self.mbed_os_support()
+
+        # This plugin only works on Windows
+        if os_name and os_name.startswith('Windows'):
+            return True
+        return False
+
+    def setup(self, *args, **kwargs):
+        """! Configure plugin, this function should be called before plugin execute() method is used.
+        """
+        # Note you need to have jlink.exe on your system path!
+        self.JLINK = 'jlink.exe'
+        return True
+
+    def execute(self, capability, *args, **kwargs):
+        """! Executes capability by name
+
+        @param capability Capability name
+        @param args Additional arguments
+        @param kwargs Additional arguments
+
+        @details Each capability e.g. may directly just call some command line program or execute building pythonic function
+
+        @return Capability call return value
+        """
+        result = False
+        if self.check_parameters(capability, *args, **kwargs) is True:
+            if capability == 'ublox':
+                # Example:
+                # JLINK.exe --CommanderScript aCommandFile
+                cmd = [self.JLINK,
+                       '-CommanderScript',
+                       r'reset.jlink']
+                result = self.run_command(cmd)
+        return result
+
+
+def load_plugin():
+    """ Returns plugin available in this module
+    """
+    return HostTestPluginResetMethod_ublox()


### PR DESCRIPTION
After merge of `mbed-os` pull request [3011](https://github.com/ARMmbed/mbed-os/pull/3011) , this pull request adds the necessary hook files to use `htrun` tests on the `SARA_NBIOT_EVK` target (since the target does not currently include a magic chip).