### PR TITLE
Catching serial port failure quickly

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
@@ -66,7 +66,6 @@ class ConnectorPrimitive(object):
         """! Returns LAST_ERROR value
         @return Value of self.LAST_ERROR
         """
-        raise NotImplementedError
         return self.LAST_ERROR
 
     def finish(self):

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -134,9 +134,6 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
             self.selected_resource,
             self.selected_resource.is_connected])
 
-    def error(self):
-        return self.LAST_ERROR
-
     def finish(self):
         # Finally once we're done with the resource
         # we disconnect and release the allocation

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -120,9 +120,6 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
     def connected(self):
         return bool(self.serial)
 
-    def error(self):
-        return self.LAST_ERROR
-
     def finish(self):
         if self.serial:
             self.serial.close()

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -139,6 +139,14 @@ def conn_process(event_queue, dut_event_queue, config):
 
     # Create connector instance with proper configuration
     connector = conn_primitive_factory(conn_resource, config, event_queue, logger)
+
+    # If the connector failed, stop the process now
+    if not connector.connected():
+        logger.prn_err("Failed to connect to resource")
+        connector.finish()
+        event_queue.put(('__notify_conn_lost', connector.error(), time()))
+        return 0
+
     # Create simple buffer we will use for Key-Value protocol data
     kv_buffer = KiViBufferWalker()
 


### PR DESCRIPTION
Currently, if the serial port fails to open then htrun still attempts to send the `sync` command. This PR checks the serial port before writing to it. If it is not connected, it fails with a relevant error message. It also allows the connector primitives to use the default implementation for the `error` function since they were identical any way.

### Test log __before__ changes with a serial error (notice the `sync` is still sent)
```
mbedgt: mbed-host-test-runner: started
[1478124379.62][HTST][INF] host test executor ver. 1.1.4
[1478124379.62][HTST][INF] copy image onto target...
[1478124379.62][COPY][INF] Waiting up to 60 sec for '110100004420312041474339323037313330303997969903' mount point (current is 'D:')...
        1 file(s) copied.
[1478124395.29][HTST][INF] starting host test process...
[1478124395.65][CONN][INF] starting connection process...
[1478124395.65][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1478124395.65][CONN][INF] initializing serial port listener...
[1478124395.65][HTST][INF] setting timeout to: 60 sec
[1478124395.65][SERI][INF] serial(port=COM308, baudrate=9600, timeout=0.01)
[1478124395.65][PLGN][INF] Waiting up to 60 sec for '110100004420312041474339323037313330303997969903' serial port (current is 'COM308')...
[1478124395.72][SERI][ERR] could not open port 'COM308': WindowsError(5, 'Access is denied.')
[1478124395.72][CONN][INF] sending up to 2 __sync packets (specified with --sync=2)
[1478124395.72][CONN][INF] sending preamble '76fdea46-0354-44ed-a044-74c6a295fdfb'
[1478124395.72][SERI][TXD] {{__sync;76fdea46-0354-44ed-a044-74c6a295fdfb}}
[1478124395.73][HTST][ERR] connection lost, serial.Serial(COM308, 9600, 0): could not open port 'COM308': WindowsError(5, 'Access is denied.')
[1478124395.73][HTST][WRN] stopped to consume events due to __notify_conn_lost event
[1478124395.73][HTST][INF] __exit_event_queue received
[1478124395.73][HTST][INF] test suite run finished after 0.08 sec...
[1478124395.73][HTST][INF] CONN exited with code: 0
[1478124395.73][HTST][INF] No events in queue
[1478124395.73][HTST][INF] host test result() call skipped, received: ioerr_serial
[1478124395.73][HTST][WRN] missing __exit event from DUT
[1478124395.73][HTST][INF] calling blocking teardown()
[1478124395.73][HTST][INF] teardown() finished
[1478124395.73][HTST][INF] {{result;ioerr_serial}}
mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped and returned 'IOERR_SERIAL'
mbedgt: test case summary event not found
        no test case report present, assuming test suite to be a single test case!
        test suite: tests-mbedmicro-rtos-mbed-mail
        test case: tests-mbedmicro-rtos-mbed-mail
mbedgt: test on hardware with target id: 110100004420312041474339323037313330303997969903
mbedgt: test suite 'tests-mbedmicro-rtos-mbed-mail' .................................................. IOERR_SERIAL in 16.56 sec
        test case: 'tests-mbedmicro-rtos-mbed-mail' .................................................. ERROR in 16.56 sec
mbedgt: test case summary: 0 passes, 1 failure
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.4020987711
mbedgt: test suite report:
+------------------+---------------+--------------------------------+--------------+--------------------+-------------+
| target           | platform_name | test suite                     | result       | elapsed_time (sec) | copy_method |
+------------------+---------------+--------------------------------+--------------+--------------------+-------------+
| NRF52_DK-GCC_ARM | NRF52_DK      | tests-mbedmicro-rtos-mbed-mail | IOERR_SERIAL | 16.56              | shell       |
+------------------+---------------+--------------------------------+--------------+--------------------+-------------+
mbedgt: test suite results: 1 IOERR_SERIAL
mbedgt: test case report:
+------------------+---------------+--------------------------------+--------------------------------+--------+--------+--------+--------------------+
| target           | platform_name | test suite                     | test case                      | passed | failed | result | elapsed_time (sec) |
+------------------+---------------+--------------------------------+--------------------------------+--------+--------+--------+--------------------+
| NRF52_DK-GCC_ARM | NRF52_DK      | tests-mbedmicro-rtos-mbed-mail | tests-mbedmicro-rtos-mbed-mail | 0      | 1      | ERROR  | 16.56              |
+------------------+---------------+--------------------------------+--------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 1 ERROR
mbedgt: completed in 21.72 sec
mbedgt: exited with code 1
```

### Test log __after__ changes with a serial error (no more `sync`!)
```
mbedgt: mbed-host-test-runner: started
[1478124418.07][HTST][INF] host test executor ver. 1.1.4
[1478124418.07][HTST][INF] copy image onto target...
[1478124418.07][COPY][INF] Waiting up to 60 sec for '110100004420312041474339323037313330303997969903' mount point (current is 'D:')...
        1 file(s) copied.
[1478124433.74][HTST][INF] starting host test process...
[1478124434.08][CONN][INF] starting connection process...
[1478124434.08][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1478124434.08][CONN][INF] initializing serial port listener...
[1478124434.08][SERI][INF] serial(port=COM308, baudrate=9600, timeout=0.01)
[1478124434.08][PLGN][INF] Waiting up to 60 sec for '110100004420312041474339323037313330303997969903' serial port (current is 'COM308')...
[1478124434.10][HTST][INF] setting timeout to: 60 sec
[1478124434.15][SERI][ERR] could not open port 'COM308': WindowsError(5, 'Access is denied.')
[1478124434.15][CONN][ERR] Failed to connect to resource
[1478124434.16][HTST][ERR] connection lost, serial.Serial(COM308, 9600, 0): could not open port 'COM308': WindowsError(5, 'Access is denied.')
[1478124434.16][HTST][WRN] stopped to consume events due to __notify_conn_lost event
[1478124434.16][HTST][INF] __exit_event_queue received
[1478124434.16][HTST][INF] test suite run finished after 0.07 sec...
[1478124434.16][HTST][INF] CONN exited with code: 0
[1478124434.16][HTST][INF] No events in queue
[1478124434.16][HTST][INF] host test result() call skipped, received: ioerr_serial
[1478124434.16][HTST][WRN] missing __exit event from DUT
[1478124434.16][HTST][INF] calling blocking teardown()
[1478124434.16][HTST][INF] teardown() finished
[1478124434.16][HTST][INF] {{result;ioerr_serial}}
mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped and returned 'IOERR_SERIAL'
mbedgt: test case summary event not found
        no test case report present, assuming test suite to be a single test case!
        test suite: tests-mbedmicro-rtos-mbed-mail
        test case: tests-mbedmicro-rtos-mbed-mail
mbedgt: test on hardware with target id: 110100004420312041474339323037313330303997969903
mbedgt: test suite 'tests-mbedmicro-rtos-mbed-mail' .................................................. IOERR_SERIAL in 16.62 sec
        test case: 'tests-mbedmicro-rtos-mbed-mail' .................................................. ERROR in 16.62 sec
mbedgt: test case summary: 0 passes, 1 failure
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.7281427031
mbedgt: test suite report:
+------------------+---------------+--------------------------------+--------------+--------------------+-------------+
| target           | platform_name | test suite                     | result       | elapsed_time (sec) | copy_method |
+------------------+---------------+--------------------------------+--------------+--------------------+-------------+
| NRF52_DK-GCC_ARM | NRF52_DK      | tests-mbedmicro-rtos-mbed-mail | IOERR_SERIAL | 16.62              | shell       |
+------------------+---------------+--------------------------------+--------------+--------------------+-------------+
mbedgt: test suite results: 1 IOERR_SERIAL
mbedgt: test case report:
+------------------+---------------+--------------------------------+--------------------------------+--------+--------+--------+--------------------+
| target           | platform_name | test suite                     | test case                      | passed | failed | result | elapsed_time (sec) |
+------------------+---------------+--------------------------------+--------------------------------+--------+--------+--------+--------------------+
| NRF52_DK-GCC_ARM | NRF52_DK      | tests-mbedmicro-rtos-mbed-mail | tests-mbedmicro-rtos-mbed-mail | 0      | 1      | ERROR  | 16.62              |
+------------------+---------------+--------------------------------+--------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 1 ERROR
mbedgt: completed in 22.66 sec
mbedgt: exited with code 1
```

Please review @mazimkhan 