### PR TITLE
Unification of poll_ing_timeout used in serial and remote conn primitive

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -278,8 +278,8 @@ def init_host_test_cli_params():
                       action="store_true",
                       help='Skips use of reset plugin. Note: target will not be reset')
 
-    parser.add_option('-P', '--pooling-timeout',
-                      dest='pooling_timeout',
+    parser.add_option('-P', '--polling-timeout',
+                      dest='polling_timeout',
                       default=60,
                       metavar="NUMBER",
                       type="int",

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -283,7 +283,7 @@ def init_host_test_cli_params():
                       default=60,
                       metavar="NUMBER",
                       type="int",
-                      help='Timeout in sec for mbed-ls mount point and serial port readiness. Default 60 sec')
+                      help='Timeout in sec for readiness of mount point and serial port of local or remote device. Default 60 sec')
 
     parser.add_option('-b', '--send-break',
                       dest='send_break_cmd',

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
@@ -74,9 +74,3 @@ class ConnectorPrimitive(object):
         """
         raise NotImplementedError
 
-    def get_timeout(self):
-        """
-        Returns connection polling timeout.
-        :return:
-        """
-        return self.polling_timeout

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
@@ -24,6 +24,7 @@ class ConnectorPrimitive(object):
     def __init__(self, name):
         self.LAST_ERROR = None
         self.logger = HtrunLogger(name)
+        self.polling_timeout = 60
 
     def write_kv(self, key, value):
         """! Forms and sends Key-Value protocol message.
@@ -72,3 +73,10 @@ class ConnectorPrimitive(object):
         """! Handle DUT dtor like (close resource) operations here
         """
         raise NotImplementedError
+
+    def get_timeout(self):
+        """
+        Returns connection polling timeout.
+        :return:
+        """
+        return self.polling_timeout

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -31,6 +31,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         self.platform_name = config.get('platform_name', None)
         self.baudrate = config.get('baudrate', DEFAULT_BAUD_RATE)
         self.image_path = config.get('image_path', None)
+        self.polling_timeout = int(config.get('polling_timeout', 60))
 
         # Global Resource Mgr tool-kit
         self.remote_module = None

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -32,7 +32,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         self.timeout = 0.01  # 10 milli sec
         self.config = config
         self.target_id = self.config.get('target_id', None)
-        self.serial_pooling = config.get('serial_pooling', 60)
+        self.polling_timeout = config.get('polling_timeout', 60)
         self.forced_reset_timeout = config.get('forced_reset_timeout', 1)
 
         # Values used to call serial port listener...
@@ -44,7 +44,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         #
         # Note: This listener opens serial port and keeps connection so reset plugin uses
         # serial port object not serial port name!
-        _, serial_port = HostTestPluginBase().check_serial_port_ready(self.port, target_id=self.target_id, timeout=self.serial_pooling)
+        _, serial_port = HostTestPluginBase().check_serial_port_ready(self.port, target_id=self.target_id, timeout=self.polling_timeout)
         if serial_port != self.port:
             # Serial port changed for given targetID
             self.logger.prn_inf("serial port changed from '%s to '%s')"% (self.port, serial_port))

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -88,7 +88,7 @@ def conn_primitive_factory(conn_resource, config, event_queue, logger):
         # Get extra configuration related to serial port
         port = config.get('port')
         baudrate = config.get('baudrate')
-        serial_pooling = int(config.get('serial_pooling', 60))
+        serial_pooling = int(config.get('polling_timeout', 60))
 
         logger.prn_inf("notify event queue about extra %d sec timeout for serial port pooling"%serial_pooling)
         event_queue.put(('__timeout', serial_pooling, time()))
@@ -104,17 +104,17 @@ def conn_primitive_factory(conn_resource, config, event_queue, logger):
     elif conn_resource == 'grm':
         # Start GRM (Gloabal Resource Mgr) collection
 
-        # Get extra configuration related to remote host
-        remote_pooling = int(config.get('remote_pooling', 30))
-
-        # Adding extra timeout for connection to remote resource host
-        logger.prn_inf("notify event queue about extra %d sec timeout for remote connection"%remote_pooling)
-        event_queue.put(('__timeout', remote_pooling, time()))
-
         logger.prn_inf("initializing global resource mgr listener... ")
         connector = RemoteConnectorPrimitive(
             'GLRM',
             config=config)
+        # Get extra configuration related to remote host
+        remote_polling = connector.get_timeout()
+
+        # Adding extra timeout for connection to remote resource host
+        logger.prn_inf("notify event queue about extra %d sec timeout for remote connection"%remote_polling)
+        event_queue.put(('__timeout', remote_polling, time()))
+
         return connector
 
     else:

--- a/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_mbed.py
@@ -79,7 +79,7 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
 
         # This optional parameter can be used if TargetID is provided (-t switch)
         target_id = kwargs.get('target_id', None)
-        pooling_timeout = kwargs.get('pooling_timeout', 60)
+        pooling_timeout = kwargs.get('polling_timeout', 60)
 
         result = False
         if self.check_parameters(capability, *args, **kwargs):

--- a/mbed_host_tests/host_tests_plugins/module_copy_shell.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_shell.py
@@ -59,7 +59,7 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
 
         # This optional parameter can be used if TargetID is provided (-t switch)
         target_id = kwargs.get('target_id', None)
-        pooling_timeout = kwargs.get('pooling_timeout', 60)
+        pooling_timeout = kwargs.get('polling_timeout', 60)
 
         result = False
         if self.check_parameters(capability, *args, **kwargs):

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -152,7 +152,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "program_cycle_s" : self.options.program_cycle_s,
                 "reset_type" : self.options.forced_reset_type,
                 "target_id" : self.options.target_id,
-                "serial_pooling" : self.options.pooling_timeout,
+                "polling_timeout" : self.options.polling_timeout,
                 "forced_reset_timeout" : self.options.forced_reset_timeout,
                 "sync_behavior" : self.options.sync_behavior,
                 "platform_name" : self.options.micro,

--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -42,7 +42,7 @@ class Mbed:
         self.image_path = self.options.image_path.strip('"') if self.options.image_path is not None else ''
         self.copy_method = self.options.copy_method
         self.program_cycle_s = float(self.options.program_cycle_s if self.options.program_cycle_s is not None else 2.0)
-        self.pooling_timeout = self.options.pooling_timeout
+        self.polling_timeout = self.options.polling_timeout
 
         # Serial port settings
         self.serial_baud = DEFAULT_BAUD_RATE
@@ -119,7 +119,7 @@ class Mbed:
                                         serial=port,
                                         destination_disk=disk,
                                         target_id=self.target_id,
-                                        pooling_timeout=self.pooling_timeout)
+                                        pooling_timeout=self.polling_timeout)
         return result
 
     def hw_reset(self):


### PR DESCRIPTION
Changes:
- Unify polling timeout use by serial and remote connection primitive
- Fix name from pooling to polling
- Fixes https://github.com/ARMmbed/htrun/issues/136
- Recommended change in greentea to pass the option ```--poll-time``` to htrun