### PR TITLE
Log comparision feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Circle CI](https://circleci.com/gh/ARMmbed/htrun.svg?style=svg)](https://circleci.com/gh/ARMmbed/htrun)
+﻿[![Circle CI](https://circleci.com/gh/ARMmbed/htrun.svg?style=svg)](https://circleci.com/gh/ARMmbed/htrun)
 [![Coverage Status](https://coveralls.io/repos/github/ARMmbed/htrun/badge.svg?branch=master)](https://coveralls.io/github/ARMmbed/htrun?branch=master)
 [![PyPI version](https://badge.fury.io/py/mbed-host-tests.svg)](https://badge.fury.io/py/mbed-host-tests)
 
@@ -1009,3 +1009,208 @@ Here you can find references to modules and repositories contain examples of tes
 * ```minar``` module contains [test cases](https://github.com/ARMmbed/minar/tree/master/test) written without ```utest```. Note: ```utest``` may use ```minar``` for callback scheduling and can't be use to test ```minar``` itself.
 * ```mbed-drivers``` module contains [test cases](https://github.com/ARMmbed/mbed-drivers/tree/master/test) written with and without ```utest``` harness. Currently all ```mbed-drivers``` tests are using [build-in to ```htrun``` host tests](https://github.com/ARMmbed/htrun/tree/master/mbed_host_tests/host_tests).
 * And finally ```sockets``` module contains [test cases](https://github.com/ARMmbed/sockets/tree/master/test) with [custom host tests](https://github.com/ARMmbed/sockets/tree/master/test/host_tests).
+
+# Testing mbed-os examples
+
+mbed-os examples are essentially sample apps written as inspirational code for developers to understand the mbed-os APIs and coding paradigms. Before every mbed-os release all examples are tested across all supported configs and platforms. There is already a large set examples available and as they grow it is important to automate them. Hence automating examples make sense. Although it is important not to pollute them with test like instrumentation. As that will defeat the purpose of examples being simple and specific. 
+
+Hence the strategy for testing examples is based on observation instead of interaction. An example's serial logging is captured and converted into a templated log. All successive executions of this example should match this log.
+
+Templated log simply means a log with text that does not change or regular expressions relacing original text. Below is an example of the templated log:
+```
+							      >	Using Ethernet LWIP
+								
+							      >	Client IP Address is 10.2.203.139
+								
+							      >	Connecting with developer.mbed.org
+								
+Starting the TLS handshake...
+								Starting the TLS handshake...
+								
+							      >	TLS connection to developer.mbed.org established
+								
+Server certificate:
+								Server certificate:
+								
+							      >	
+								    cert. version     : 3
+							      >	
+								    serial number     : 11:21:B8:47:9B:21:6C:B1:C6:AF:BC:5D:0
+							      >	
+								    issuer name       : C=BE, O=GlobalSign nv-sa, CN=GlobalSi
+							      >	
+								    subject name      : C=GB, ST=Cambridgeshire, L=Cambridge,
+							      >	
+								    issued  on        : 2016-03-03 12:26:08
+							      >	
+								    expires on        : 2017-04-05 10:31:02
+							      >	
+								    signed using      : RSA with SHA-256
+							      >	
+								    RSA key size      : 2048 bits
+							      >	
+								    basic constraints : CA=false
+							      >	
+								    subject alt name  : *.mbed.com, mbed.org, *.mbed.org, mbe
+							      >	
+								    key usage         : Digital Signature, Key Encipherment
+							      >	
+								    ext key usage     : TLS Web Server Authentication, TLS We
+
+Certificate verification passed
+								
+								Certificate verification passed
+								
+
+								
+								
+							      >	HTTPS: Received 439 chars from server
+								
+							      >	HTTPS: Received 200 OK status ... [OK]
+								
+HTTPS: Received 'Hello world!' status ... [OK]
+								HTTPS: Received 'Hello world!' status ... [OK]
+								
+HTTPS: Received message:
+								HTTPS: Received message:
+								
+
+								
+								
+							      >	HTTP/1.1 200 OK
+								
+							      >	Server: nginx/1.7.10
+								
+							      >	Date: Thu, 01 Dec 2016 13:56:32 GMT
+								
+							      >	Content-Type: text/plain
+								
+							      >	Content-Length: 14
+								
+							      >	Connection: keep-alive
+								
+							      >	Last-Modified: Fri, 27 Jul 2012 13:30:34 GMT
+								
+							      >	Accept-Ranges: bytes
+								
+							      >	Cache-Control: max-age=36000
+								
+							      >	Expires: Thu, 01 Dec 2016 23:56:32 GMT
+								
+							      >	X-Upstream-L3: 172.17.0.3:80
+								
+							      >	X-Upstream-L2: developer-sjc-indigo-2-nginx
+								
+							      >	Strict-Transport-Security: max-age=31536000; includeSubdomain
+								
+
+								
+								
+Hello world!
+								Hello world!
+								
+								
+
+```
+
+Please observe above that all the lines that have data that changes from execution to execution (on right) have been removed. It makes it possible htrun to comapre these logs. htrun matches lines from the compare log (on left) one by one. It keeps on looking for a line until it matches. Once matched it moves on to match the next line. If it finds all lines from the compare log in the target serial output stream. Then it halts and passes the examples.
+
+Another example with regular examples is shown below:
+
+```
+							      |	
+								
+							      |	
+								
+  SHA-256                  :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  SHA-256                  :       1922 Kb/s,         61 cycl
+								
+  SHA-512                  :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  SHA-512                  :        614 Kb/s,        191 cycl
+								
+  AES-CBC-128              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-CBC-128              :       1401 Kb/s,         83 cycl
+								
+  AES-CBC-192              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-CBC-192              :       1231 Kb/s,         95 cycl
+								
+  AES-CBC-256              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-CBC-256              :       1097 Kb/s,        106 cycl
+								
+  AES-GCM-128              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-GCM-128              :        429 Kb/s,        273 cycl
+								
+  AES-GCM-192              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-GCM-192              :        412 Kb/s,        285 cycl
+								
+  AES-GCM-256              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-GCM-256              :        395 Kb/s,        297 cycl
+								
+  AES-CCM-128              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-CCM-128              :        604 Kb/s,        194 cycl
+								
+  AES-CCM-192              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-CCM-192              :        539 Kb/s,        217 cycl
+								
+  AES-CCM-256              :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  AES-CCM-256              :        487 Kb/s,        241 cycl
+								
+  CTR_DRBG \(NOPR\)          :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  CTR_DRBG (NOPR)          :       1145 Kb/s,        102 cycl
+								
+  CTR_DRBG \(PR\)            :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  CTR_DRBG (PR)            :        821 Kb/s,        142 cycl
+								
+  HMAC_DRBG SHA-256 \(NOPR\) :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  HMAC_DRBG SHA-256 (NOPR) :        219 Kb/s,        537 cycl
+								
+  HMAC_DRBG SHA-256 \(PR\)   :\s*\d+ Kb/s,\s*\d+ cycles/byte
+							      |	  HMAC_DRBG SHA-256 (PR)   :        193 Kb/s,        612 cycl
+								
+  RSA-2048                 :\s*\d+ ms/ public
+							      |	  RSA-2048                 :      30 ms/ public
+								
+  RSA-2048                 :\s*\d+ ms/private
+							      |	  RSA-2048                 :    1054 ms/private
+								
+  RSA-4096                 :\s*\d+ ms/ public
+							      |	  RSA-4096                 :     101 ms/ public
+								
+  RSA-4096                 :\s*\d+ ms/private
+							      |	  RSA-4096                 :    5790 ms/private
+								
+  ECDHE-secp384r1          :\s*\d+ ms/handshake
+							      |	  ECDHE-secp384r1          :    1023 ms/handshake
+								
+  ECDHE-secp256r1          :\s*\d+ ms/handshake
+							      |	  ECDHE-secp256r1          :     678 ms/handshake
+								
+  ECDHE-Curve25519         :\s*\d+ ms/handshake
+							      |	  ECDHE-Curve25519         :     580 ms/handshake
+								
+  ECDH-secp384r1           :\s*\d+ ms/handshake
+							      |	  ECDH-secp384r1           :     503 ms/handshake
+								
+  ECDH-secp256r1           :\s*\d+ ms/handshake
+							      |	  ECDH-secp256r1           :     336 ms/handshake
+								
+  ECDH-Curve25519          :\s*\d+ ms/handshake
+							      |	  ECDH-Curve25519          :     300 ms/handshake
+								
+
+
+```
+
+To capture a log use following option:
+```
+mbedhtrun -d D: -p COM46 -m K64F -f .\BUILD\K64F\GCC_ARM\benchmark.bin --serial-output-file compare.log
+```
+
+Option ```--serial-output-file``` takes file name as argument and writes the target serial output to the file. Edit the file to remove lines that will change in successive executions. Put regular expressions if needed at places like benchmark numbers in above log. With these edits you are left with a template good for comparison.
+
+Use following command to test the example and the comparison log:
+```
+mbedhtrun -d D: -p COM46 -m K64F -f .\BUILD\K64F\GCC_ARM\benchmark.bin --compare-log compare.log
+```
+
+A tested comparison log can be checked into GitHub with the examples and can be used in the CI for example verification.

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -302,6 +302,16 @@ def init_host_test_cli_params():
                       action="store_true",
                       help='More verbose mode')
 
+    parser.add_option('', '--serial-output-file',
+                      dest='serial_output_file',
+                      default=None,
+                      help='Save target serial output to this file.')
+
+    parser.add_option('', '--compare-log',
+                      dest='compare_log',
+                      default=None,
+                      help='Log file to compare with the serial output from target.')
+
     parser.add_option('', '--version',
                       dest='version',
                       default=False,


### PR DESCRIPTION
This feature adds option ```--compare-log``` to compare target serial with a templated comparision log. Please see ```README.md``` changes for details.

This is PR is open for discussion and adding more scenarios in consideration.

@adbridge @bridadan Please review.