### PR TITLE
Fixes traceback caused by wrong variable reference

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -51,7 +51,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
 
         startTime = time.time()
         self.logger.prn_inf("serial(port=%s, baudrate=%d, timeout=%s)"% (self.port, self.baudrate, self.timeout))
-        while time.time() - startTime < self.serial_pooling:
+        while time.time() - startTime < self.polling_timeout:
             try:
                 # TIMEOUT: While creating Serial object timeout is delibrately passed as 0. Because blocking in Serial.read
                 # impacts thread and mutliprocess functioning in Python. Hence, instead in self.read() s delay (sleep()) is
@@ -64,7 +64,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
                     self.timeout,
                     str(e))
                 self.logger.prn_err(str(e))
-                self.logger.prn_err("Retry after 1 sec until %s seconds" % self.serial_pooling)
+                self.logger.prn_err("Retry after 1 sec until %s seconds" % self.polling_timeout)
             else:
                 self.reset_dev_via_serial(delay=self.forced_reset_timeout)
                 break


### PR DESCRIPTION
Looks like some references to `self.serial_pooling` were missed in #137. It's currently causing a traceback on master, this should fix it!