### PR TITLE
Log comparison changes

### DIFF
--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -84,9 +84,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         if options.compare_log:
             with open(options.compare_log, "r") as f:
-                self.compare_log = []
-                for line in f:
-                    self.compare_log.append(line.strip())
+                self.compare_log = f.read().splitlines()
 
         else:
             self.compare_log = None
@@ -257,7 +255,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 if self.serial_output_file:
                     if key == '__rxd_line':
                         with open(self.serial_output_file, "a") as f:
-                            f.write("%s\n" % value)
+                            f.write(value)
 
                 # In this mode we only check serial output against compare log.
                 if self.compare_log:
@@ -266,7 +264,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             self.logger.prn_inf("Target log matches compare log!")
                             result = True
                             break
-                elif consume_preamble_events:
+
+                if consume_preamble_events:
                     if key == '__timeout':
                         # Override default timeout for this event queue
                         start_time = time()


### PR DESCRIPTION
This change stops stripping the received lines, making the saved output look closer to the actual output you see in a serial terminal.

It also fixes an issue when comparing an example output where the timeouts are set differently. This is because when the loop enters the "cosume_premable_events" part, it adds an extra 60 seconds to execution time. This was only being done when "serial_output_file" was set, now it's being done when "compare_log" is set as well (by changing the if/else structure).