### PR TITLE
Fixes --skip-reset functionality

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -34,6 +34,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         self.target_id = self.config.get('target_id', None)
         self.polling_timeout = config.get('polling_timeout', 60)
         self.forced_reset_timeout = config.get('forced_reset_timeout', 1)
+        self.skip_reset = config.get('skip_reset', False)
 
         # Values used to call serial port listener...
 
@@ -66,7 +67,8 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
                 self.logger.prn_err(str(e))
                 self.logger.prn_err("Retry after 1 sec until %s seconds" % self.polling_timeout)
             else:
-                self.reset_dev_via_serial(delay=self.forced_reset_timeout)
+                if not self.skip_reset:
+                    self.reset_dev_via_serial(delay=self.forced_reset_timeout)
                 break
             time.sleep(1)
 

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -167,6 +167,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "sync_behavior" : self.options.sync_behavior,
                 "platform_name" : self.options.micro,
                 "image_path" : self.mbed.image_path,
+                "skip_reset": self.options.skip_reset,
             }
 
             if self.options.global_resource_mgr:


### PR DESCRIPTION
Somehow '--skip-reset' was being ignored. This PR restores the
functionality. Should fix #142 (original issue located here: https://github.com/ARMmbed/mbed-cli/issues/411)