### PR TITLE
Handle regex exception when comparing log

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -34,6 +34,7 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         self.target_id = self.config.get('target_id', None)
         self.polling_timeout = config.get('polling_timeout', 60)
         self.forced_reset_timeout = config.get('forced_reset_timeout', 1)
+        self.skip_reset = config.get('skip_reset', False)
 
         # Values used to call serial port listener...
 
@@ -66,7 +67,8 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
                 self.logger.prn_err(str(e))
                 self.logger.prn_err("Retry after 1 sec until %s seconds" % self.polling_timeout)
             else:
-                self.reset_dev_via_serial(delay=self.forced_reset_timeout)
+                if not self.skip_reset:
+                    self.reset_dev_via_serial(delay=self.forced_reset_timeout)
                 break
             time.sleep(1)
 

--- a/mbed_host_tests/host_tests_plugins/__init__.py
+++ b/mbed_host_tests/host_tests_plugins/__init__.py
@@ -31,6 +31,8 @@ import module_copy_shell
 import module_copy_mbed
 import module_reset_mbed
 import module_power_cycle_mbed
+import module_copy_pyocd
+import module_reset_pyocd
 
 # Additional, non standard platforms
 import module_copy_silabs
@@ -51,6 +53,7 @@ HOST_TEST_PLUGIN_REGISTRY = host_test_registry.HostTestRegistry()
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_mbed.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_shell.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_mbed.load_plugin())
+HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_pyocd.load_plugin())
 
 # Extra platforms support
 #HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_mps2.load_plugin())
@@ -60,6 +63,7 @@ HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_silabs.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_stlink.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_stlink.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_power_cycle_mbed.load_plugin())
+HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_pyocd.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_ublox.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_ublox.load_plugin())
 #HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_jn51xx.load_plugin())

--- a/mbed_host_tests/host_tests_plugins/module_copy_pyocd.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_pyocd.py
@@ -1,0 +1,139 @@
+"""
+mbed SDK
+Copyright (c) 2016-2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Russ Butler <russ.butler@arm.com>
+"""
+
+import os
+from host_test_plugins import HostTestPluginBase
+from pyOCD.board import MbedBoard
+from intelhex import IntelHex
+import itertools
+
+
+def _enum_continguous_addr_start_end(addr_list):
+    """Generator to get contiguous address ranges with start and end address"""
+    for _, b in itertools.groupby(enumerate(addr_list), lambda (x, y): y - x):
+        b = list(b)
+        yield b[0][1], b[-1][1]
+
+
+class HostTestPluginCopyMethod_pyOCD(HostTestPluginBase):
+    # Plugin interface
+    name = 'HostTestPluginCopyMethod_pyOCD'
+    type = 'CopyMethod'
+    stable = True
+    capabilities = ['pyocd']
+    required_parameters = ['image_path', 'target_id']
+
+    def __init__(self):
+        """ ctor
+        """
+        HostTestPluginBase.__init__(self)
+
+    def setup(self, *args, **kwargs):
+        """ Configure plugin, this function should be called before plugin execute() method is used.
+        """
+        return True
+
+    def execute(self, capability, *args, **kwargs):
+        """! Executes capability by name
+
+        @param capability Capability name
+        @param args Additional arguments
+        @param kwargs Additional arguments
+        @return Capability call return value
+        """
+        if not self.check_parameters(capability, *args, **kwargs):
+            return False
+
+        if not kwargs['image_path']:
+            self.print_plugin_error("Error: image path not specified")
+            return False
+
+        if not kwargs['target_id']:
+            self.print_plugin_error("Error: Target ID")
+            return False
+
+        target_id = kwargs['target_id']
+        image_path = os.path.normpath(kwargs['image_path'])
+        with MbedBoard.chooseBoard(board_id=target_id) as board:
+            # Performance hack!
+            # Eventually pyOCD will know default clock speed
+            # per target
+            test_clock = 10000000
+            target_type = board.getTargetType()
+            if target_type == "nrf51":
+                # Override clock since 10MHz is too fast
+                test_clock = 1000000
+            if target_type == "ncs36510":
+                # Override clock since 10MHz is too fast
+                test_clock = 1000000
+
+            # Configure link
+            board.link.set_clock(test_clock)
+            board.link.set_deferred_transfer(True)
+
+            # Collect address, data pairs for programming
+            program_list = []
+            extension = os.path.splitext(image_path)[1]
+            if extension == '.bin':
+                # Binary file format
+                memory_map = board.target.getMemoryMap()
+                rom_region = memory_map.getBootMemory()
+                with open(image_path, "rb") as file_handle:
+                    program_data = file_handle.read()
+                program_list.append((rom_region.start, program_data))
+            elif extension == '.hex':
+                # Intel hex file format
+                ihex = IntelHex(image_path)
+                addresses = ihex.addresses()
+                addresses.sort()
+                for start, end in _enum_continguous_addr_start_end(addresses):
+                    size = end - start + 1
+                    data = ihex.tobinarray(start=start, size=size)
+                    data = bytearray(data)
+                    program_list.append((start, data))
+            else:
+                # Unsupported
+                raise Exception("Unsupported file format %s" % extension)
+
+            # Program data
+            flash_builder = board.flash.getFlashBuilder()
+            for addr, data in program_list:
+                flash_builder.addData(addr, list(bytearray(data)))
+            flash_builder.program()
+
+            # Read back and verify programming was successful
+            for addr, data in program_list:
+                read_data = board.target.readBlockMemoryUnaligned8(addr,
+                                                                   len(data))
+                read_data = bytearray(read_data)
+                if bytes(data) != bytes(read_data):
+                    raise Exception("Flash programming error - failed to "
+                                    "program address 0x%x size %s" %
+                                    (addr, len(data)))
+
+            # Cleanup
+            board.uninit(resume=False)
+
+        return True
+
+
+def load_plugin():
+    """ Returns plugin available in this module
+    """
+    return HostTestPluginCopyMethod_pyOCD()

--- a/mbed_host_tests/host_tests_plugins/module_reset_pyocd.py
+++ b/mbed_host_tests/host_tests_plugins/module_reset_pyocd.py
@@ -1,0 +1,79 @@
+"""
+mbed SDK
+Copyright (c) 2016-2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Russ Butler <russ.butler@arm.com>
+"""
+
+import re
+import pkg_resources
+from host_test_plugins import HostTestPluginBase
+from os.path import join, basename
+from pyOCD.board import MbedBoard
+
+
+class HostTestPluginResetMethod_pyOCD(HostTestPluginBase):
+
+    # Plugin interface
+    name = 'HostTestPluginResetMethod_pyOCD'
+    type = 'ResetMethod'
+    stable = True
+    capabilities = ['pyocd']
+    required_parameters = ['target_id']
+
+    def __init__(self):
+        """! ctor
+        @details We can check module version by referring to version attribute
+        import pkg_resources
+        print pkg_resources.require("mbed-host-tests")[0].version
+        '2.7'
+        """
+        HostTestPluginBase.__init__(self)
+
+    def setup(self, *args, **kwargs):
+        """! Configure plugin, this function should be called before plugin execute() method is used.
+        """
+        return True
+
+    def execute(self, capability, *args, **kwargs):
+        """! Executes capability by name
+
+        @param capability Capability name
+        @param args Additional arguments
+        @param kwargs Additional arguments
+        @details Each capability e.g. may directly just call some command line program or execute building pythonic function
+        @return Capability call return value
+        """
+        if not kwargs['target_id']:
+            self.print_plugin_error("Error: target_id not set")
+            return False
+
+        result = False
+        if self.check_parameters(capability, *args, **kwargs) is True:
+            if kwargs['target_id']:
+                if capability == 'pyocd':
+                    target_id = kwargs['target_id']
+                    with MbedBoard.chooseBoard(board_id=target_id) as board:
+                        board.target.reset()
+                        board.target.resume()
+                        board.uninit(resume=False)
+                        result = True
+        return result
+
+
+def load_plugin():
+    """! Returns plugin available in this module
+    """
+    return HostTestPluginResetMethod_pyOCD()

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -22,6 +22,7 @@ import re
 import sys
 import traceback
 from time import time
+from sre_compile import error
 from Queue import Empty as QueueEmpty   # Queue here refers to the module, not a class
 
 from mbed_host_tests import BaseHostTest
@@ -167,6 +168,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 "sync_behavior" : self.options.sync_behavior,
                 "platform_name" : self.options.micro,
                 "image_path" : self.mbed.image_path,
+                "skip_reset": self.options.skip_reset,
             }
 
             if self.options.global_resource_mgr:
@@ -526,6 +528,10 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         if self.compare_log_idx < len(self.compare_log):
             regex = self.compare_log[self.compare_log_idx]
             # Either the line is matched as is or it is checked as a regular expression.
-            if regex in line or re.search(regex, line):
-                self.compare_log_idx += 1
+            try:
+                if regex in line or re.search(regex, line):
+                    self.compare_log_idx += 1
+            except error:
+                # May not be a regular expression
+                return False
         return self.compare_log_idx == len(self.compare_log)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='mbed-host-tests',
-      version='1.1.5',
+      version='1.1.7',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,
@@ -55,4 +55,6 @@ setup(name='mbed-host-tests',
       install_requires=["PySerial>=3.0",
                         "PrettyTable>=0.7.2",
                         "requests",
-                        "mbed-ls>=1.0.0"])
+                        "mbed-ls>=1.0.0",
+                        "pyOCD>=0.8.1a1",
+                        "intelhex"])


### PR DESCRIPTION
Lines from template log are first matched literally and then as regex. In failure cases a line that is expected to match literally will not match and be tried as a regex patter. If the line has unqualified regex it may raise exception. Hence regex exception should be handled as a possibility and match() function should return False (no match) on exception.

@bridadan @adbridge Please review.