### PR TITLE
do not clear selected resource when connect fails

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -90,7 +90,6 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
             self.selected_resource.openConnection(parameters=serial_parameters)
         except self.remote_module.resources.ResourceError as e:
             self.logger.prn_inf("openConnection() failed")
-            self.selected_resource = None
             raise e
 
     def __remote_disconnect(self):


### PR DESCRIPTION
If remote connection fails do not clear selected resource because it's still allocated

Fix for #153 