### PR TITLE
Added sync failure status: mbed greentea module should be synced with…

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Key-value protocol was developed and is used to provide communication layer betw
     * User can't register callbacks to "system events" with few exceptions.
     * Reserved event/message keys have leading ```__``` in name:
       * ```__sync``` - sync message, used by master and DUT to handshake.
+      * ```__notify_sync_failed``` - sent by host when sync response not received from DUT.
       * ```__timeout``` - timeout in sec, sent by DUT after ```{{sync;UUID}}``` is received.
       * ```__version``` - ```greentea-client``` version send from DUT to host.
       * ```__host_test_name``` - host test name, sent by DUT after ```{{sync;UUID}}``` is received.

--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -39,6 +39,10 @@ class BaseHostTestAbstract(object):
         if self.__event_queue:
             self.__event_queue.put(('__notify_conn_lost', text, time()))
 
+    def __notify_sync_failed(self, text):
+        if self.__event_queue:
+            self.__event_queue.put(('__notify_sync_failed', text, time()))
+
     def __notify_dut(self, key, value):
         """! Send data over serial to DUT """
         if self.__dut_event_queue:

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -135,7 +135,7 @@ def conn_process(event_queue, dut_event_queue, config):
     sync_behavior = int(config.get('sync_behavior', 1))
     sync_timeout = config.get('sync_timeout', 1.0)
     conn_resource = config.get('conn_resource', 'serial')
-    last_sync = 0
+    last_sync = False
 
     # Create connector instance with proper configuration
     connector = conn_primitive_factory(conn_resource, config, event_queue, logger)
@@ -279,11 +279,11 @@ def conn_process(event_queue, dut_event_queue, config):
                         #Sync behavior will be zero and if last sync fails we should report connection
                         #lost
                         if sync_behavior == 0:
-                            last_sync = 1
+                            last_sync = True
                     else:
                         __notify_conn_lost()
                         break
-            elif last_sync == 1:
+            elif last_sync == True:
                 #SYNC lost connection event : Device not responding, send sync failed
                 __notify_sync_failed()
                 break

--- a/mbed_host_tests/host_tests_runner/host_test.py
+++ b/mbed_host_tests/host_tests_runner/host_test.py
@@ -43,7 +43,8 @@ class HostTestResults(object):
             RESULT_NOT_DETECTED = "not_detected",
             RESULT_MBED_ASSERT = "mbed_assert",
             RESULT_PASSIVE = "passive",
-            RESULT_BUILD_FAILED = 'build_failed'
+            RESULT_BUILD_FAILED = 'build_failed',
+            RESULT_SYNC_FAILED = 'sync_failed'
         )
 
         # Magically creates attributes in this class corresponding
@@ -68,7 +69,8 @@ class HostTestResults(object):
             self.TestResults.RESULT_NOT_DETECTED,
             self.TestResults.RESULT_MBED_ASSERT,
             self.TestResults.RESULT_PASSIVE,
-            self.TestResults.RESULT_BUILD_FAILED
+            self.TestResults.RESULT_BUILD_FAILED,
+            self.TestResults.RESULT_SYNC_FAILED
         ]
 
     def get_test_result_int(self, test_result_str):

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -154,6 +154,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
 
         self.logger.prn_inf("starting host test process...")
 
+
         # Create device info here as it may change after restart.
         config = {
             "digest" : "serial",
@@ -224,7 +225,6 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 return elapsed_time, (key, value, timestamp)
 
         p = start_conn_process()
-
         conn_process_started = False
         try:
             (key, value, timestamp) = event_queue.get(timeout=self.options.process_start_timeout)
@@ -316,6 +316,13 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                     elif key == '__sync':
                         # This is DUT-Host Test handshake event
                         self.logger.prn_inf("sync KV found, uuid=%s, timestamp=%f"% (str(value), timestamp))
+                    elif key == '__notify_sync_failed':
+                        # This event is sent by conn_process, SYNC failed
+                        self.logger.prn_err(value)
+                        self.logger.prn_wrn("stopped to consume events due to %s event"% key)
+                        callbacks_consume = False
+                        result = self.RESULT_SYNC_FAILED
+                        event_queue.put(('__exit_event_queue', 0, time()))
                     elif key == '__notify_conn_lost':
                         # This event is sent by conn_process, DUT connection was lost
                         self.logger.prn_err(value)


### PR DESCRIPTION
@bridadan @mazimkhan @studavekar : Please review code

Many boards in CI fail just after sync, suggestion to which was re-flash firmware and re-try. Capturing SYNC failure as separate for such cases.

Note: Code changes in greentea should be pulled along with this request