### PR TITLE
force flash the device when using RaaS

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -79,7 +79,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         # Remote DUT connection, flashing and reset...
         try:
             self.__remote_disconnect()
-            self.__remote_flashing(self.image_path)
+            self.__remote_flashing(self.image_path, forceflash=True)
             self.__remote_connect(baudrate=self.baudrate)
             self.__remote_reset()
         except Exception as e:


### PR DESCRIPTION
this is required as when force flash is not enabled, If device is not flashed
probably because of out-of-order copy or any other reason. if its reported
as flashed properly because FAIL.TXT or ASSERT.txt is not created we may see
next test failure.