### PR TITLE
add args --sync-timeout parameter delay between __sync packets

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -202,7 +202,7 @@ def init_host_test_cli_params():
                       dest="sync_timeout",
                       default=5,
                       type=int,
-                      help="Define delay between between __sync packet (Default is 5 seconds)",
+                      help="Define delay in seconds between __sync packet (Default is 5 seconds)",
                       metavar="SYNC_TIMEOUT")
 
     parser.add_option("-f", "--image-path",

--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -198,6 +198,13 @@ def init_host_test_cli_params():
                       help="Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of times (Default 2 time)",
                       metavar="SYNC_BEHAVIOR")
 
+    parser.add_option("", "--sync-timeout",
+                      dest="sync_timeout",
+                      default=5,
+                      type=int,
+                      help="Define delay between between __sync packet (Default is 5 seconds)",
+                      metavar="SYNC_TIMEOUT")
+
     parser.add_option("-f", "--image-path",
                       dest="image_path",
                       help="Path with target's binary image",

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -173,7 +173,8 @@ class DefaultTestSelector(DefaultTestSelectorBase):
             "platform_name" : self.options.micro,
             "image_path" : self.mbed.image_path,
             "skip_reset": self.options.skip_reset,
-            "tags" : self.options.tag_filters
+            "tags" : self.options.tag_filters,
+            "sync_timeout": self.options.sync_timeout
         }
 
         if self.options.global_resource_mgr:


### PR DESCRIPTION
Currently this argument was used but never set, always defaulting to 1 sec. In
case of RaaS and when device boot takes longer we end up of sending multiple
sync_packet causing few test to fail like echo test.