### PR TITLE
Allow a host test to reset the device under test

### DIFF
--- a/mbed_host_tests/host_tests/base_host_test.py
+++ b/mbed_host_tests/host_tests/base_host_test.py
@@ -64,6 +64,14 @@ class BaseHostTestAbstract(object):
         if self.__event_queue:
             self.__event_queue.put(('__reset_dut', value, time()))
 
+    def reset(self):
+        """
+        Reset the device under test and continue running the host test
+        :return:
+        """
+        if self.__event_queue:
+            self.__event_queue.put(("__reset", "0", time()))
+
     def notify_conn_lost(self, text):
         """! Notify main even loop that there was a DUT-host test connection error
         @param consume If True htrun will process (consume) all remaining events

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive.py
@@ -67,6 +67,11 @@ class ConnectorPrimitive(object):
         """! Flush read/write channels of DUT """
         raise NotImplementedError
 
+    def reset(self):
+        """! Reset the dut
+        """
+        raise NotImplementedError
+
     def connected(self):
         """! Check if there is a connection to DUT
         @return True if there is conenction to DUT (read/write/flush API works)
@@ -83,4 +88,3 @@ class ConnectorPrimitive(object):
         """! Handle DUT dtor like (close resource) operations here
         """
         raise NotImplementedError
-

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -160,5 +160,8 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
             except self.remote_module.resources.ResourceError as e:
                 self.logger.prn_err("RemoteConnectorPrimitive.finish() failed, reason: " + str(e))
 
+    def reset(self):
+        self.__remote_reset()
+
     def __del__(self):
         self.finish()

--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_serial.py
@@ -137,5 +137,8 @@ class SerialConnectorPrimitive(ConnectorPrimitive):
         if self.serial:
             self.serial.close()
 
+    def reset(self):
+        self.reset_dev_via_serial(self.forced_reset_timeout)
+
     def __del__(self):
         self.finish()

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -231,10 +231,15 @@ def conn_process(event_queue, dut_event_queue, config):
         else:
             # Return if state machine in host_test_default has finished to end process
             if key == '__host_test_finished' and value == True:
-                logger.prn_inf("received special even '%s' value='%s', finishing"% (key, value))
+                logger.prn_inf("received special event '%s' value='%s', finishing"% (key, value))
                 connector.finish()
                 return 0
-            if not connector.write_kv(key, value):
+            elif key == '__reset':
+                logger.prn_inf("received special event '%s', resetting dut" % (key))
+                connector.reset()
+                event_queue.put(("reset_complete", 0, time()))
+            elif not connector.write_kv(key, value):
+                connector.write_kv(key, value)
                 __notify_conn_lost()
                 break
 

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -366,6 +366,9 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                         self.logger.prn_inf("%s(%s)" % (key, str(value)))
                         result = value
                         event_queue.put(('__exit_event_queue', 0, time()))
+                    elif key == '__reset':
+                        # This event only resets the dut, not the host test
+                        dut_event_queue.put(('__reset', True, time()))
                     elif key == '__reset_dut':
                         # Disconnect to avoid connection lost event
                         dut_event_queue.put(('__host_test_finished', True, time()))


### PR DESCRIPTION
Add a host test reset function to allow the current DUT to be reset. This allow unexpected power loss to be tested.

CC @bridadan @studavekar @theotherjimmy 