### PR TITLE
Keep the same extension of the executable files copied to MPS2

### DIFF
--- a/mbed_host_tests/host_tests_plugins/module_copy_mps2.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_mps2.py
@@ -47,7 +47,9 @@ class HostTestPluginCopyMethod_MPS2(HostTestPluginBase):
         @return Returns True if copy (flashing) was successful
         """
         result = True
-        destination_path = os.path.join(destination_disk, "mbed.bin")
+        # Keep the same extension in the test spec and on the MPS2
+        _, extension = os.path.splitext(image_path);
+        destination_path = os.path.join(destination_disk, "mbed" + extension)
         try:
             copy(image_path, destination_path)
             # sync command on mac ignores command line argumjents.

--- a/mbed_host_tests/host_tests_plugins/module_copy_mps2.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_mps2.py
@@ -1,6 +1,6 @@
 """
 mbed SDK
-Copyright (c) 2011-2015 ARM Limited
+Copyright (c) 2011-2018 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,10 +36,11 @@ class HostTestPluginCopyMethod_MPS2(HostTestPluginBase):
         """
         HostTestPluginBase.__init__(self)
 
-    def mps2_bin_copy(self, image_path, destination_disk):
+    def mps2_copy(self, image_path, destination_disk):
         """! mps2 copy method for "mbed enabled" devices.
-            this copies the binary always as mbed.bin
-        @param image_path Path to binary file to be flashed
+             This copies the file on the MPS2 keeping the same extension but
+             renaming it "mbed.extension"
+        @param image_path Path to file to be copied
         @param destination_disk Path to destination (mbed mount point)
 
         @details this uses shutil copy to copy the file.
@@ -52,7 +53,7 @@ class HostTestPluginCopyMethod_MPS2(HostTestPluginBase):
         destination_path = os.path.join(destination_disk, "mbed" + extension)
         try:
             copy(image_path, destination_path)
-            # sync command on mac ignores command line argumjents.
+            # sync command on mac ignores command line arguments.
             if os.name == 'posix':
                 result = self.run_command('sync -f %s' % destination_path, shell=True)
         except Exception as e:
@@ -98,7 +99,7 @@ class HostTestPluginCopyMethod_MPS2(HostTestPluginBase):
                     # available in result (_, destination_disk) of check_mount_point_ready
                     result, destination_disk = self.check_mount_point_ready(destination_disk, target_id=target_id, timeout=pooling_timeout)  # Blocking
                     if result:
-                        result = self.mps2_bin_copy(image_path, destination_disk)
+                        result = self.mps2_copy(image_path, destination_disk)
         return result
 
 

--- a/test/mps2_copy.py
+++ b/test/mps2_copy.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2018 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import os
+
+from mbed_host_tests.host_tests_plugins.module_copy_mps2 import HostTestPluginCopyMethod_MPS2
+
+class MPS2CopyTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.mps2_copy_plugin = HostTestPluginCopyMethod_MPS2()
+        self.filename = "toto.bin"
+        # Create the empty file named self.filename
+        open(self.filename, "w+").close()
+
+    def tearDown(self):
+        os.remove(self.filename)
+
+    def test_copy_bin(self):
+        # Check that file has been copied as "mbed.bin"
+        self.mps2_copy_plugin.mps2_copy(self.filename, ".")
+        self.assertTrue(os.path.isfile("mbed.bin"))
+        os.remove("mbed.bin")
+
+    def test_copy_elf(self):
+        # Check that file has been copied as "mbed.elf"
+        os.rename(self.filename, "toto.elf")
+        self.filename = "toto.elf"
+        self.mps2_copy_plugin.mps2_copy(self.filename, ".")
+        self.assertTrue(os.path.isfile("mbed.elf"))
+        os.remove("mbed.elf")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
To allow to write .elf file path in the test_spec.json file, this patch
keeps the same extension when copying mbed.extension file onto the MPS2
board.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>