### PR TITLE
set default value for --program_cycle_s

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -239,7 +239,8 @@ def init_host_test_cli_params():
 
     parser.add_option("-C", "--program_cycle_s",
                       dest="program_cycle_s",
-                      help="Program cycle sleep. Define how many seconds you want wait after copying binary onto target",
+                      default=4,
+                      help="Program cycle sleep. Define how many seconds you want wait after copying binary onto target (Default is 4 second)",
                       type="float",
                       metavar="PROGRAM_CYCLE_S")
 


### PR DESCRIPTION
The default value was picked from https://github.com/ARMmbed/greentea/blob/747460ccd80917264fbef79ae13ff9834d014450/mbed_greentea/mbed_target_info.py#L46 
