### PR TITLE
Several improvements for Global Resource Manager connection

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_primitive_remote.py
@@ -31,8 +31,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         self.platform_name = config.get('platform_name', None)
         self.baudrate = config.get('baudrate', DEFAULT_BAUD_RATE)
         self.image_path = config.get('image_path', None)
-        self.polling_timeout = int(config.get('polling_timeout', 60))
-        self.allocate_requirements = { "platform_name": self.platform_name }
+        self.allocate_requirements = {"platform_name": self.platform_name}
 
         if self.config["tags"]:
             self.allocate_requirements["tags"] = {}
@@ -53,12 +52,14 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         # We want to load global resource manager module by name from command line (switch --grm)
         try:
             self.remote_module = __import__(self.grm_module)
-        except ImportError as e:
-            self.logger.prn_err("unable to load global resource manager '%s' module!"% self.grm_module)
+        except ImportError as error:
+            self.logger.prn_err("unable to load global resource manager '%s' module!" % self.grm_module)
+            self.logger.prn_err(str(error))
             self.remote_module = None
             return False
 
-        self.logger.prn_inf("remote resources initialization: remote(host=%s, port=%s)"% (self.grm_host, self.grm_port))
+        self.logger.prn_inf("remote resources initialization: remote(host=%s, port=%s)" %
+                            (self.grm_host, self.grm_port))
 
         # Connect to remote global resource manager
         self.client = self.remote_module.create(host=self.grm_host, port=self.grm_port)
@@ -72,8 +73,8 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         try:
             self.selected_resource = self.client.allocate(self.allocate_requirements)
 
-        except self.remote_module.resources.ResourceError as e:
-            self.logger.prn_err("can't allocate resource: '%s', reason: %s"% (self.platform_name, str(e)))
+        except self.remote_module.resources.ResourceError as error:
+            self.logger.prn_err("can't allocate resource: '%s', reason: %s" % (self.platform_name, str(error)))
             return False
 
         # Remote DUT connection, flashing and reset...
@@ -81,28 +82,22 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
             self.__remote_flashing(self.image_path, forceflash=True)
             self.__remote_connect(baudrate=self.baudrate)
             self.__remote_reset()
-        except Exception as e:
-            self.logger.prn_err(str(e))
+        except Exception as error:
+            self.logger.prn_err(str(error))
             return False
         return True
 
-    def __remote_connect(self, baudrate=DEFAULT_BAUD_RATE, buffer_size=6):
+    def __remote_connect(self, baudrate=DEFAULT_BAUD_RATE):
         """! Open remote connection to DUT """
-        self.logger.prn_inf("opening connection to platform at baudrate='%s, bufferSize=%d'"% (baudrate, buffer_size))
+        self.logger.prn_inf("opening connection to platform at baudrate='%s'" % baudrate)
         if not self.selected_resource:
             raise Exception("remote resource not exists!")
         try:
-            serial_parameters = self.remote_module.SerialParameters(lineMode=False, baudrate=baudrate, bufferSize=buffer_size)
-            self.selected_resource.openConnection(parameters=serial_parameters)
-        except self.remote_module.resources.ResourceError as e:
-            self.logger.prn_inf("openConnection() failed")
-            raise e
-
-    def __remote_disconnect(self):
-        if not self.selected_resource:
-            raise Exception("remote resource not exists!")
-        if self.selected_resource.is_connected:
-            self.selected_resource.closeConnection()
+            serial_parameters = self.remote_module.SerialParameters(baudrate=baudrate)
+            self.selected_resource.open_connection(parameters=serial_parameters)
+        except self.remote_module.resources.ResourceError as error:
+            self.logger.prn_inf("open_connection() failed")
+            raise error
 
     def __remote_reset(self):
         """! Use GRM remote API to reset DUT """
@@ -114,7 +109,7 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
 
     def __remote_flashing(self, filename, forceflash=False):
         """! Use GRM remote API to flash DUT """
-        self.logger.prn_inf("remote resources flashing with '%s'..."% filename)
+        self.logger.prn_inf("remote resources flashing with '%s'..." % filename)
         if not self.selected_resource:
             raise Exception("remote resource not exists!")
         if not self.selected_resource.flash(filename, forceflash=forceflash):
@@ -124,28 +119,34 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         """! Read 'count' bytes of data from DUT """
         if not self.selected_resource:
             raise Exception("remote resource not exists!")
-        date = str()
+        data = str()
         try:
             data = self.selected_resource.read(count)
-        except self.remote_module.resources.ResourceError as e:
-            self.logger.prn_err("RemoteConnectorPrimitive.read(%d): %s"% (count, str(e)))
+        except self.remote_module.resources.ResourceError as error:
+            self.logger.prn_err("RemoteConnectorPrimitive.read(%d): %s" % (count, str(error)))
         return data
 
     def write(self, payload, log=False):
         """! Write 'payload' to DUT """
         if self.selected_resource:
-            self.selected_resource.write(payload)
-            if log:
-                self.logger.prn_txd(payload)
-        return True
+            try:
+                self.selected_resource.write(payload)
+                if log:
+                    self.logger.prn_txd(payload)
+                return True
+            except self.remote_module.resources.ResourceError as error:
+                self.LAST_ERROR = "remote write error: %s" % str(error)
+                self.logger.prn_err(str(error))
+        return False
 
     def flush(self):
         pass
 
     def connected(self):
         return all([self.remote_module,
-            self.selected_resource,
-            self.selected_resource.is_connected])
+                    self.selected_resource,
+                    self.selected_resource.is_allocated,
+                    self.selected_resource.is_connected])
 
     def finish(self):
         # Finally once we're done with the resource
@@ -153,12 +154,15 @@ class RemoteConnectorPrimitive(ConnectorPrimitive):
         if self.selected_resource:
             try:
                 if self.selected_resource.is_connected:
-                    self.selected_resource.closeConnection()
+                    self.selected_resource.close_connection()
+            except self.remote_module.resources.ResourceError as error:
+                self.logger.prn_err("RemoteConnectorPrimitive.finish():close_connection failed, reason: " + str(error))
+            try:
                 if self.selected_resource.is_allocated:
                     self.selected_resource.release()
                     self.selected_resource = None
-            except self.remote_module.resources.ResourceError as e:
-                self.logger.prn_err("RemoteConnectorPrimitive.finish() failed, reason: " + str(e))
+            except self.remote_module.resources.ResourceError as error:
+                self.logger.prn_err("RemoteConnectorPrimitive.finish():release failed, reason: " + str(error))
 
     def reset(self):
         self.__remote_reset()

--- a/test/conn_primitive_remote.py
+++ b/test/conn_primitive_remote.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2018 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import mock
+
+
+from mbed_host_tests.host_tests_conn_proxy.conn_primitive_remote import RemoteConnectorPrimitive
+
+
+class RemoteResourceMock(object):
+    def __init__(self, requirements):
+        self._is_allocated = True
+        self._is_connected = True
+        self.requirements = requirements
+        self.open_connection = mock.MagicMock()
+        self.close_connection = mock.MagicMock()
+        self.write = mock.MagicMock()
+        self.read = mock.MagicMock()
+        self.read.return_value = "abc"
+        self.disconnect = mock.MagicMock()
+        self.flash = mock.MagicMock()
+        self.reset = mock.MagicMock()
+        self.release = mock.MagicMock()
+
+    @property
+    def is_connected(self):
+        return self._is_connected
+    @property
+    def is_allocated(self):
+        return self._is_allocated
+
+
+class RemoteModuleMock(object):
+
+    class SerialParameters(object):
+        def __init__(self, baudrate):
+            self.baudrate = baudrate
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.is_allocated_mock = mock.MagicMock()
+        self.allocate = mock.MagicMock()
+        self.allocate.side_effect = lambda req: RemoteResourceMock(req)
+        self.get_resources = mock.MagicMock()
+        self.get_resources.return_value = [1]
+
+    @staticmethod
+    def create(host, port):
+        return RemoteModuleMock(host, port)
+
+class BasicHostTestsTestCase(unittest.TestCase):
+
+    def test_constructor(self):
+        config = {
+            "grm_module": "RemoteModuleMock",
+            "tags": "a,b",
+            "image_path": "test.bin",
+            "platform_name": "my_platform",
+        }
+        importer = mock.MagicMock()
+        importer.side_effect = lambda x: RemoteModuleMock
+        remote = RemoteConnectorPrimitive("remote", config, importer)
+        importer.assert_called_once_with("RemoteModuleMock")
+
+        remote.client.get_resources.called_once()
+        self.assertEqual(remote.remote_module, RemoteModuleMock)
+        self.assertIsInstance(remote.client, RemoteModuleMock)
+        self.assertIsInstance(remote.selected_resource, RemoteResourceMock)
+
+        # allocate is called
+        remote.client.allocate.assert_called_once_with({
+            'platform_name': config.get('platform_name'),
+            'tags': {"a": True, "b": True}})
+
+        # flash is called
+        remote.selected_resource.open_connection.called_once_with("test.bin")
+
+        # open_connection is called
+        remote.selected_resource.open_connection.called_once()
+        connect = remote.selected_resource.open_connection.call_args[1]
+        self.assertEqual(connect["parameters"].baudrate, 9600)
+
+        # reset once
+        remote.selected_resource.reset.assert_called_once_with()
+
+    def test_write(self):
+        config = {
+            "grm_module": "RemoteModuleMock",
+            "tags": "a,b",
+            "image_path": "test.bin",
+            "platform_name": "my_platform",
+        }
+        importer = mock.MagicMock()
+        importer.side_effect = lambda x: RemoteModuleMock
+        remote = RemoteConnectorPrimitive("remote", config, importer)
+        remote.write("abc")
+        remote.selected_resource.write.assert_called_once_with("abc")
+
+    def test_read(self):
+        config = {
+            "grm_module": "RemoteModuleMock",
+            "tags": "a,b",
+            "image_path": "test.bin",
+            "platform_name": "my_platform",
+        }
+        importer = mock.MagicMock()
+        importer.side_effect = lambda x: RemoteModuleMock
+        remote = RemoteConnectorPrimitive("remote", config, importer)
+        data = remote.read(6)
+        remote.selected_resource.read.assert_called_once_with(6)
+        self.assertEqual(data, "abc")
+
+    def test_reset(self):
+        config = {
+            "grm_module": "RemoteModuleMock",
+            "tags": "a,b",
+            "image_path": "test.bin",
+            "platform_name": "my_platform",
+        }
+        importer = mock.MagicMock()
+        importer.side_effect = lambda x: RemoteModuleMock
+        remote = RemoteConnectorPrimitive("remote", config, importer)
+        data = remote.reset()
+        self.assertEqual(remote.selected_resource.reset.call_count, 2)
+
+    def test_finish(self):
+        config = {
+            "grm_module": "RemoteModuleMock",
+            "tags": "a,b",
+            "image_path": "test.bin",
+            "platform_name": "my_platform",
+        }
+        importer = mock.MagicMock()
+        importer.side_effect = lambda x: RemoteModuleMock
+        remote = RemoteConnectorPrimitive("remote", config, importer)
+        resource = remote.selected_resource
+        remote.finish()
+        self.assertEqual(remote.selected_resource, None)
+        resource.close_connection.assert_called_once()
+        resource.release.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Status
**IN PROGRESS**

Relates to MBEDOSTEST-37

## Changes:
* remove obsolete API usages and use new one
* fixes bug from read in case of reading fails
* fixes finish to releasing resource in case of close_connection fails
* fix connected function
* connected() validates that resource is also allocated
* validates that write() success
* release resource if flash or connection fails
* catch generic Exception when allocate fails
* validates that resource is allocated and connected before writing/reading it
* validates that resource is allocated before releasing
* improve traces
* pylint cleaning
* add basic tests