### PR TITLE
Fixing incorrect inclusion of fastmodel as default connproxy

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -292,7 +292,7 @@ def init_host_test_cli_params():
     parser.add_option('', '--fm',
                       dest='fast_model_connection',
                       metavar="CONFIG",
-                      default='DEFAULT',
+                      default=None,
                       help=fm_help)
 
     parser.add_option('', '--run',


### PR DESCRIPTION
This should fix https://github.com/ARMmbed/greentea/issues/274#issuecomment-395660594.

Could you take a quick look @jamesbeyond?