### PR TITLE
fix 'mbedhtrun crashes when no parameters given'

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -31,6 +31,7 @@ import imp
 import inspect
 from os import listdir
 from os.path import isfile, join, abspath
+import sys
 from optparse import OptionParser
 from optparse import SUPPRESS_HELP
 from mbed_host_tests import host_tests_plugins
@@ -357,4 +358,9 @@ def init_host_test_cli_params():
     parser.epilog = """Example: mbedhtrun -d E: -p COM5 -f "test.bin" -C 4 -c shell -m K64F"""
 
     (options, _) = parser.parse_args()
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit()
+
     return options


### PR DESCRIPTION
MBEDOSTEST-90

**master:**
```
$ mbedhtrun
[1530001200.88][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
[1530001200.91][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
[1530001200.92][HTST][INF] host test executor ver. 1.3.1
[1530001200.92][HTST][INF] copy image onto target...
Traceback (most recent call last):
  File "/usr/local/bin/mbedhtrun", line 9, in <module>
    load_entry_point('mbed-host-tests==1.3.1', 'console_scripts', 'mbedhtrun')()
  File "build/bdist.linux-x86_64/egg/mbed_host_tests/mbedhtrun.py", line 34, in main
  File "build/bdist.linux-x86_64/egg/mbed_host_tests/host_tests_runner/host_test_default.py", line 524, in execute
  File "build/bdist.linux-x86_64/egg/mbed_host_tests/host_tests_runner/mbed_base.py", line 179, in copy_image
  File "build/bdist.linux-x86_64/egg/mbed_host_tests/host_tests_runner/mbed_base.py", line 97, in get_remount_count
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

**modified:**
```
$ mbedhtrun
[1530001232.08][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
[1530001232.11][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
Usage: mbedhtrun [options]

Flash, reset and perform host supervised tests on mbed platforms

Options:
  -h, --help            show this help message and exit
  -m MICRO, --micro=MICRO
                        Target microcontroller name
  -p PORT, --port=PORT  Serial port of the target
  -d DISK_PATH, --disk=DISK_PATH
                        Target disk (mount point) path
  -t TARGET_ID, --target-id=TARGET_ID
                        Unique Target Id or mbed platform
  --sync=SYNC_BEHAVIOR  Define how many times __sync packet will be sent to
                        device: 0: none; -1: forever; 1,2,3... - number of
                        times (Default 2 time)
  --sync-timeout=SYNC_TIMEOUT
                        Define delay in seconds between __sync packet (Default
                        is 5 seconds)
  -f IMAGE_PATH, --image-path=IMAGE_PATH
                        Path with target's binary image
  -c COPY_METHOD, --copy=COPY_METHOD
                        Copy (flash the target) method selector. Plugin
                        support: copy, cp, default, eACommander, eACommander-
                        usb, mps2, pyocd, shell, shutil, stlink, ublox, xcopy
  --retry-copy=RETRY_COPY
                        Number of attempts to flash the target
  --tag-filters=TAG_FILTERS
                        Comma seperated list of device tags used when
                        allocating a target to specify required hardware or
                        attributes [--tag-filters tag1,tag2]
  -r FORCED_RESET_TYPE, --reset=FORCED_RESET_TYPE
                        Forces different type of reset. Plugin support:
                        default, eACommander, eACommander-usb, power_cycle,
                        pyocd, reboot.txt, stlink, ublox
  -C PROGRAM_CYCLE_S, --program_cycle_s=PROGRAM_CYCLE_S
                        Program cycle sleep. Define how many seconds you want
                        wait after copying binary onto target (Default is 4
                        second)
  -R NUMBER, --reset-timeout=NUMBER
                        When forcing a reset using option -r you can set up
                        after reset idle delay in seconds (Default is 1
                        second)
  --process-start-timeout=NUMBER
                        This sets the maximum time in seconds to wait for an
                        internal process to start. This mostly only affects
                        machines under heavy load (Default is 60 seconds)
  -e ENUM_HOST_TESTS, --enum-host-tests=ENUM_HOST_TESTS
                        Define directory with local host tests
  --test-cfg=JSON_TEST_CONFIGURATION
                        Pass to host test class data about host test
                        configuration
  --list                Prints registered host test and exits
  --plugins             Prints registered plugins and exits
  -g GLOBAL_RESOURCE_MGR, --grm=GLOBAL_RESOURCE_MGR
                        [Experimental] Global resource manager service module
                        name, IP and port, example
                        remote_client:10.2.123.43:3334
  --run                 Runs binary image on target (workflow: flash, reset,
                        output console)
  --skip-flashing       Skips use of copy/flash plugin. Note: target will not
                        be reflashed
  --skip-reset          Skips use of reset plugin. Note: target will not be
                        reset
  -P NUMBER, --polling-timeout=NUMBER
                        Timeout in sec for readiness of mount point and serial
                        port of local or remote device. Default 60 sec
  -b, --send-break      Send reset signal to board on specified port (-p PORT)
                        and print serial output. You can combine this with (-r
                        RESET_TYPE) switch
  --baud-rate=BAUD_RATE
                        Baud rate of target, overrides values from mbed-ls,
                        disk/mount point (-d, --disk-path), and serial port -p
                        <port>:<baud rate>
  -v, --verbose         More verbose mode
  --serial-output-file=SERIAL_OUTPUT_FILE
                        Save target serial output to this file.
  --compare-log=COMPARE_LOG
                        Log file to compare with the serial output from
                        target.
  --version             Prints package version and exits

Example: mbedhtrun -d E: -p COM5 -f "test.bin" -C 4 -c shell -m K64F
```