### PR TITLE
Fix 'mbedhtrun tries to flash non existing file multiple times'

### DIFF
--- a/mbed_host_tests/host_tests_runner/mbed_base.py
+++ b/mbed_host_tests/host_tests_runner/mbed_base.py
@@ -175,6 +175,14 @@ class Mbed:
             retry_copy = self.retry_copy
         target_id = self.target_id
 
+        if not image_path:
+            self.logger.prn_err("Error: image path not specified")
+            return False
+
+        if not os.path.isfile(image_path):
+            self.logger.prn_err("Error: image file (%s) not found" % image_path)
+            return False
+
         for count in range(0, retry_copy):
             initial_remount_count = get_remount_count(disk)
             # Call proper copy method


### PR DESCRIPTION
MBEDOSTEST-91

**master(fail):**
```
$ mbedhtrun -d /media/alekla01/DAPLINK -p /dev/ttyACM0 -f "test.bin" -C 4 -c shell -m K64F
[1530018523.87][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
[1530018523.89][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
[1530018523.91][HTST][INF] host test executor ver. 1.3.1
[1530018523.91][HTST][INF] copy image onto target...
cp: cannot stat 'test.bin': No such file or directory
[1530018523.92][COPY][ERR] [ret=1] Command: ['cp', 'test.bin', '/media/alekla01/DAPLINK/test.bin']
cp: cannot stat 'test.bin': No such file or directory
[1530018527.93][COPY][ERR] [ret=1] Command: ['cp', 'test.bin', '/media/alekla01/DAPLINK/test.bin']
...
```

**modified(fail):**
```
$ mbedhtrun -d /media/alekla01/DAPLINK -p /dev/ttyACM0 -f "test.bin" -C 4 -c shell -m K64F
[1530018497.71][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
[1530018497.73][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
[1530018497.75][HTST][INF] host test executor ver. 1.3.1
[1530018497.75][HTST][INF] copy image onto target...
[1530018497.75][MBED][ERR] Error: image file (test.bin) not found
$
```

**modified(success):**
```
$ mbedhtrun -d /media/alekla01/DAPLINK -p /dev/ttyACM0 -f "./BUILD/tes/K64F/GCC_ARM/features/frameworks/utest/TESTS/unit_tests/basic_test/basic_test.bin" -C 4 -m K64F
[1530018722.62][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
[1530018722.64][root]Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
[1530018722.66][HTST][INF] host test executor ver. 1.3.1
[1530018722.66][HTST][INF] copy image onto target...
[1530018731.01][MBED][WRN] Target ID not found: Skipping flash check and retry
[1530018731.02][HTST][INF] starting host test process...
```