### PR TITLE
Reset device after bad sync

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -135,6 +135,7 @@ def conn_process(event_queue, dut_event_queue, config):
 
     logger = HtrunLogger('CONN')
     logger.prn_inf("starting connection process...")
+    
 
     # Send connection process start event to host process
     # NOTE: Do not send any other Key-Value pairs before this!
@@ -168,6 +169,8 @@ def conn_process(event_queue, dut_event_queue, config):
         sync_uuid = str(uuid.uuid4())
         # Handshake, we will send {{sync;UUID}} preamble and wait for mirrored reply
         if timeout:
+            logger.prn_inf("Reset the part and send in new preamble...")
+            connector.reset()
             logger.prn_inf("resending new preamble '%s' after %0.2f sec"% (sync_uuid, timeout))
         else:
             logger.prn_inf("sending preamble '%s'"% sync_uuid)
@@ -271,6 +274,8 @@ def conn_process(event_queue, dut_event_queue, config):
                             logger.prn_inf("found SYNC in stream: {{%s;%s}} it is #%d sent, queued..."% (key, value, idx))
                         else:
                             logger.prn_err("found faulty SYNC in stream: {{%s;%s}}, ignored..."% (key, value))
+                            logger.prn_inf("Resetting the part to clear out the buffer...")
+                            connector.reset()
                     else:
                         logger.prn_wrn("found KV pair in stream: {{%s;%s}}, ignoring..."% (key, value))
 

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -273,8 +273,9 @@ def conn_process(event_queue, dut_event_queue, config):
                             logger.prn_inf("found SYNC in stream: {{%s;%s}} it is #%d sent, queued..."% (key, value, idx))
                         else:
                             logger.prn_err("found faulty SYNC in stream: {{%s;%s}}, ignored..."% (key, value))
-                            logger.prn_inf("Resetting the part to clear out the buffer...")
+                            logger.prn_inf("Resetting the part and sync timeout to clear out the buffer...")
                             connector.reset()
+                            loop_timer = time()
                     else:
                         logger.prn_wrn("found KV pair in stream: {{%s;%s}}, ignoring..."% (key, value))
 

--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -135,7 +135,6 @@ def conn_process(event_queue, dut_event_queue, config):
 
     logger = HtrunLogger('CONN')
     logger.prn_inf("starting connection process...")
-    
 
     # Send connection process start event to host process
     # NOTE: Do not send any other Key-Value pairs before this!


### PR DESCRIPTION
To solve issue: https://github.com/ARMmbed/htrun/issues/193

Solution: 

The host would send an initial sync, and if it receives a bad sync it will reset the part and wait until a certain duration  before sending the second sync packet. Meanwhile, if it receives another sync packet from DUT (if the buffer was not empty), it will reset the part again. 
Corner case: The DUT has 4 bad syncs in its buffer, and when it sent out the 3rd one, host received it and told it to reset, and then host itself reached a stage where it is ready to send second sync. At this point, device sends out the 4th sync and begins executing the tests (since there is no ack from host), and this test is one of those kind where it would continuously spew out data to host via the buffer, in this case, sending second sync would have no effect because that stage has already passed. At this point, host will not receive any echo back from device and it would eventually time out. To solve this particular corner case, while sending second sync, we should reset the device first and then send second sync packet.