### PR TITLE
disable timeout during consume_preamble_events

### DIFF
--- a/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
+++ b/mbed_host_tests/host_tests_conn_proxy/conn_proxy.py
@@ -88,10 +88,6 @@ def conn_primitive_factory(conn_resource, config, event_queue, logger):
     @param logger Host Test logger instance
     @return Object of type <ConnectorPrimitive> or None if type of connection primitive unknown (conn_resource)
     """
-    polling_timeout = int(config.get('polling_timeout', 60))
-    logger.prn_inf("notify event queue about extra %d sec timeout for serial port pooling"%polling_timeout)
-    event_queue.put(('__timeout', polling_timeout, time()))
-
     if conn_resource == 'serial':
         # Standard serial port connection
         # Notify event queue we will wait additional time for serial port to be ready

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -263,7 +263,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
         try:
             consume_preamble_events = True
 
-            while (time() - start_time) < timeout_duration:
+            while consume_preamble_events or (time() - start_time) < timeout_duration:
                 # Handle default events like timeout, host_test_name, ...
                 try:
                     (key, value, timestamp) = event_queue.get(timeout=1)
@@ -287,7 +287,6 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                 if consume_preamble_events:
                     if key == '__timeout':
                         # Override default timeout for this event queue
-                        start_time = time()
                         timeout_duration = int(value) # New timeout
                         self.logger.prn_inf("setting timeout to: %d sec"% int(value))
                     elif key == '__version':
@@ -329,6 +328,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                             result = self.RESULT_ERROR
                             event_queue.put(('__exit_event_queue', 0, time()))
 
+                        start_time = time()
                         consume_preamble_events = False
                     elif key == '__sync':
                         # This is DUT-Host Test handshake event


### PR DESCRIPTION
This pr disables **timeout in host_test_default** during setup (allocation, flashing, etc..).
 * disable **timeout** during setup (consume_preamble_events=True)
 * enable **timeout** during testing (consume_preamble_events=False)

related: MBEDOSTEST-41