### PR TITLE
Feature: dynamic timeouts

### DIFF
--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -437,7 +437,7 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                         # Dynamic timeout set
                         timeout_duration = int(value) # New timeout
                         self.logger.prn_inf("setting timeout to: %d sec"% int(value))
-                    elif key == '__timeout_adj':
+                    elif key == '__timeout_adjust':
                         # Dynamic timeout adjust
                         timeout_duration = timeout_duration + int(value) # adjust time
                         self.logger.prn_inf("adjusting timeout with %d sec (now %d)" % (int(value), timeout_duration))

--- a/mbed_host_tests/host_tests_runner/host_test_default.py
+++ b/mbed_host_tests/host_tests_runner/host_test_default.py
@@ -433,6 +433,14 @@ class DefaultTestSelector(DefaultTestSelectorBase):
                         self.logger.prn_inf("%s received"% (key))
                         callbacks__exit_event_queue = True
                         break
+                    elif key == '__timeout_set':
+                        # Dynamic timeout set
+                        timeout_duration = int(value) # New timeout
+                        self.logger.prn_inf("setting timeout to: %d sec"% int(value))
+                    elif key == '__timeout_adj':
+                        # Dynamic timeout adjust
+                        timeout_duration = timeout_duration + int(value) # adjust time
+                        self.logger.prn_inf("adjusting timeout with %d sec (now %d)" % (int(value), timeout_duration))
                     elif key in callbacks:
                         # Handle callback
                         callbacks[key](key, value, timestamp)


### PR DESCRIPTION
This minimalistic PR adds support to dynamically sett/adjust a test timeout via DUT messages `{{__timeout_set,int}}`, `{{__timeout_adjust,int}}`.

The is particularly useful when a device is making a download (say firmware update), where the speed might dynamically change based on various conditions. With this feature, the DUT might notify the host that it's alive and running, just slower than expected.

A typical usecase would be a unified IP connectivity test, where the time to complete over Ethernet and Wifi would be significantly faster than 2G/3G, let alone NBIoT/CAT-M1.

As discussed with @bridadan 