### PR TITLE
Increase reset timeout from 1 to 3 seconds to allow bootloaders to run

### DIFF
--- a/mbed_host_tests/__init__.py
+++ b/mbed_host_tests/__init__.py
@@ -138,7 +138,7 @@ def init_host_test_cli_params():
 
     parser.add_option("-R", "--reset-timeout",
                       dest="forced_reset_timeout",
-                      default=1,
+                      default=3,
                       metavar="NUMBER",
                       type="float",
                       help="When forcing a reset using option -r you can set up after reset idle delay in seconds (Default is 1 second)")


### PR DESCRIPTION
Increase reset timeout from 1 to 3 seconds to allow bootloaders to run. If you build mbed-bootloader 3.5.0 (the latest at the time of this writing), greentea/htrun will fail the tests because the bootloader takes just above 1 second to run and the application never receives the `{{__sync}}` message.

To make matters worse, currently greentea/htrun is not picking up `forced_reset_timeout` from `mbed_app.json`, only from `targets.json`. But in 99% of the usecases the bootloader is activated on application config level.

This is pretty urgent as we are not able to test mbed-bootloader with greentea/htrun together.