### PR TITLE
Fix old name reference in pyocd copy plugin

### DIFF
--- a/mbed_host_tests/host_tests_plugins/module_copy_pyocd.py
+++ b/mbed_host_tests/host_tests_plugins/module_copy_pyocd.py
@@ -67,7 +67,7 @@ class HostTestPluginCopyMethod_pyOCD(HostTestPluginBase):
             # Eventually pyOCD will know default clock speed
             # per target
             test_clock = 10000000
-            target_type = board.getTargetType()
+            target_type = session.board.target_type
             if target_type == "nrf51":
                 # Override clock since 10MHz is too fast
                 test_clock = 1000000


### PR DESCRIPTION
Corrected the reference to `board.getTargetType()` in the pyocd copy plugin to the new property name `session.board.target_type`.

Tested by using `mbedhtrun` to flash a binary to a FRDM-K64F.